### PR TITLE
Corrige le problème avec les polices de caractères

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,6 @@
 body {
   display: flex;
   flex-direction: column;
-  font-family: Arial, Helvetica, sans-serif;
 }
 
 html, body {


### PR DESCRIPTION
Supprime la ligne CSS vers les "fallback fonts".

La police de caractère utilisée étant téléchargée, il est inutile d'avoir d'autres polices.