### PR TITLE
Ajout de nouveaux fonds de carte

### DIFF
--- a/src/app/points-prelevement/page.js
+++ b/src/app/points-prelevement/page.js
@@ -2,7 +2,7 @@
 
 import {useEffect, useMemo, useState} from 'react'
 
-import {Box} from '@mui/material'
+import {Box, Select, MenuItem, FormControl, InputLabel} from '@mui/material'
 
 import {getPointsPrelevement} from '@/app/api/points-prelevement.js'
 import SidePanelLayout from '@/components/layout/side-panel.js'
@@ -27,6 +27,7 @@ const Page = () => {
     usages: []
   })
   const [filteredPoints, setFilteredPoints] = useState([])
+  const [style, setStyle] = useState('vector')
 
   // Récupération des données côté client via l'API
   useEffect(() => {
@@ -111,7 +112,39 @@ const Page = () => {
           filteredPoints={filteredPoints}
           selectedPoint={selectedPoint}
           handleSelectedPoint={handleSelectedPoint}
+          style={style}
+          setStyle={setStyle}
         />
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            backgroundColor: '#ffffff',
+            height: 70,
+            width: 300
+          }}
+        >
+          <FormControl
+            sx={{
+              m: 2,
+              position: 'absolute',
+              width: 270
+            }}
+            size='small'
+          >
+            <InputLabel>Style de la carte</InputLabel>
+            <Select
+              value={style}
+              label='Style de la carte'
+              onChange={e => setStyle(e.target.value)}
+            >
+              <MenuItem value='vector'>Plan OpenMapTiles</MenuItem>
+              <MenuItem value='plan-ign'>Plan IGN</MenuItem>
+              <MenuItem value='photo'>Photographie aérienne</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
       </Box>
     </SidePanelLayout>
   )

--- a/src/app/points-prelevement/page.js
+++ b/src/app/points-prelevement/page.js
@@ -2,7 +2,14 @@
 
 import {useEffect, useMemo, useState} from 'react'
 
-import {Box, Select, MenuItem, FormControl, InputLabel} from '@mui/material'
+import {
+  Box,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  useTheme
+} from '@mui/material'
 
 import {getPointsPrelevement} from '@/app/api/points-prelevement.js'
 import SidePanelLayout from '@/components/layout/side-panel.js'
@@ -14,6 +21,7 @@ import useEvent from '@/hook/use-event.js'
 import {extractTypeMilieu, extractUsages} from '@/lib/points-prelevement.js'
 
 const Page = () => {
+  const theme = useTheme()
   // État pour les données
   const [points, setPoints] = useState([])
   const [loading, setLoading] = useState(true)
@@ -120,7 +128,7 @@ const Page = () => {
             position: 'absolute',
             top: 0,
             left: 0,
-            backgroundColor: '#ffffff',
+            backgroundColor: theme.palette.background.default,
             height: 70,
             width: 300
           }}

--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -9,6 +9,8 @@ import 'maplibre-gl/dist/maplibre-gl.css'
 import {createRoot} from 'react-dom/client'
 
 import Popup from './popup.js'
+import photo from './styles/photo.json'
+import planIGN from './styles/plan-ign.json'
 import vector from './styles/vector.json'
 
 import {
@@ -21,6 +23,50 @@ import {
 } from '@/lib/points-prelevement.js'
 
 const SOURCE_ID = 'points-prelevement'
+const styles = {
+  photo,
+  'plan-ign': planIGN,
+  vector
+}
+
+function loadMap(map, points) {
+  // On ajoute la source en ne gardant que les points filtrés
+  map.addSource(SOURCE_ID, {
+    type: 'geojson',
+    data: createPointPrelevementFeatures(points),
+    cluster: true,
+    clusterRadius: 80,
+    clusterProperties: {
+      // Comptage pour chaque type d'environnement
+      eauSurface: ['+', ['case', eauSurface, 1, 0]],
+      eauSouterraine: ['+', ['case', eauSouterraine, 1, 0]]
+    }
+  })
+
+  // Layer combiné affichant le nom et le typeMilieu (entre parenthèses sur deux lignes)
+  map.addLayer({
+    id: 'points-prelevement-nom',
+    type: 'symbol',
+    source: SOURCE_ID,
+    filter: ['!=', 'cluster', true],
+    layout: {
+      'text-field': [
+        'concat',
+        ['get', 'nom'],
+        '\n(',
+        ['get', 'typeMilieu'],
+        ')'
+      ],
+      'text-anchor': 'bottom',
+      'text-offset': ['get', 'textOffset']
+    },
+    paint: {
+      'text-halo-color': '#fff',
+      'text-halo-width': 2,
+      'text-color': '#000'
+    }
+  })
+}
 
 /**
  * Props attendues :
@@ -28,8 +74,9 @@ const SOURCE_ID = 'points-prelevement'
  *  - filteredPoints : tableau d'id (point.id_point) correspondant aux points à afficher
  *  - selectedPoint : point sélectionné (objet ou null)
  *  - handleSelectedPoint : callback recevant l'id du point sélectionné
+ *  - style : style de la carte (photo, plan-ign, vector)
  */
-const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint}) => {
+const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint, style}) => {
   const mapContainerRef = useRef(null)
   const mapRef = useRef(null)
   const popupRef = useRef(null)
@@ -58,7 +105,7 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint}) => {
 
     const map = new maplibre.Map({
       container: mapContainerRef.current,
-      style: vector,
+      style: styles[style],
       center: [55.55, -21.13],
       zoom: 9,
       debug: true,
@@ -80,42 +127,7 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint}) => {
     mapRef.current = map
 
     map.on('load', async () => {
-      // On ajoute la source en ne gardant que les points filtrés
-      map.addSource(SOURCE_ID, {
-        type: 'geojson',
-        data: createPointPrelevementFeatures(points),
-        cluster: true,
-        clusterRadius: 80,
-        clusterProperties: {
-          // Comptage pour chaque type d'environnement
-          eauSurface: ['+', ['case', eauSurface, 1, 0]],
-          eauSouterraine: ['+', ['case', eauSouterraine, 1, 0]]
-        }
-      })
-
-      // Layer combiné affichant le nom et le typeMilieu (entre parenthèses sur deux lignes)
-      map.addLayer({
-        id: 'points-prelevement-nom',
-        type: 'symbol',
-        source: SOURCE_ID,
-        filter: ['!=', 'cluster', true],
-        layout: {
-          'text-field': [
-            'concat',
-            ['get', 'nom'],
-            '\n(',
-            ['get', 'typeMilieu'],
-            ')'
-          ],
-          'text-anchor': 'bottom',
-          'text-offset': ['get', 'textOffset']
-        },
-        paint: {
-          'text-halo-color': '#fff',
-          'text-halo-width': 2,
-          'text-color': '#000'
-        }
-      })
+      loadMap(map, points)
     })
 
     // À chaque fois que la source GeoJSON est chargée, on met à jour les markers.
@@ -266,6 +278,16 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint}) => {
       map.setPaintProperty('points-prelevement-nom', 'text-color', '#000')
     }
   }, [selectedPoint])
+
+  useEffect(() => {
+    if (mapRef.current && style && mapRef.current.isStyleLoaded()) {
+      mapRef.current.setStyle(styles[style])
+      loadMap(mapRef.current, points)
+      mapRef.current.on('render', () => {
+        updateMarkers()
+      })
+    }
+  }, [style, points, updateMarkers])
 
   return (
     <Box className='flex h-full w-full relative'>

--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -107,7 +107,7 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint, style}
       container: mapContainerRef.current,
       style: styles[style],
       center: [55.55, -21.13],
-      zoom: 9,
+      zoom: 10,
       debug: true,
       attributionControl: {compact: true}
     })

--- a/src/components/map/styles/photo.json
+++ b/src/components/map/styles/photo.json
@@ -1,0 +1,24 @@
+{
+  "version": 8,
+  "name": "Photo",
+  "sources": {
+    "ign": {
+      "type": "raster",
+      "tiles": [
+        "https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&FORMAT=image%2Fjpeg"
+      ],
+      "tileSize": 256
+    }
+  },
+  "sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
+  "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "ign",
+      "type": "raster",
+      "source": "ign",
+      "minzoom": 0,
+      "maxzoom": 18
+    }
+  ]
+}

--- a/src/components/map/styles/plan-ign.json
+++ b/src/components/map/styles/plan-ign.json
@@ -1,0 +1,24 @@
+{
+  "version": 8,
+  "name": "Plan IGN",
+  "sources": {
+    "ign": {
+      "type": "raster",
+      "tiles": [
+        "https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&FORMAT=image%2Fpng"
+      ],
+      "tileSize": 256
+    }
+  },
+  "sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
+  "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "ign",
+      "type": "raster",
+      "source": "ign",
+      "minzoom": 0,
+      "maxzoom": 18
+    }
+  ]
+}


### PR DESCRIPTION
Cette PR ajoute un sélecteur permettant à l'utilisateur de choisir un fond de carte différent.

> Le fond par défaut est toujours `OpenMapTiles` : Le fond IGN a des bandes blanches autour de l'île.

## Captures : 

![image](https://github.com/user-attachments/assets/a37d0d24-542a-4632-8212-4de6f784281e)

![image](https://github.com/user-attachments/assets/c9ff745e-69f9-4f81-bd71-224f04a5c7ad)

![image](https://github.com/user-attachments/assets/d5333983-5c8f-4368-a0d7-1dc7101df6b4)
