### PR TITLE
Supprime les "clusters" sur la carte et restaure la légende

### DIFF
--- a/src/app/points-prelevement/page.js
+++ b/src/app/points-prelevement/page.js
@@ -15,6 +15,7 @@ import {getPointsPrelevement} from '@/app/api/points-prelevement.js'
 import SidePanelLayout from '@/components/layout/side-panel.js'
 import LoadingOverlay from '@/components/loading-overlay.js'
 import Map from '@/components/map/index.js'
+import Legend from '@/components/map/legend.js'
 import MapFilters from '@/components/map/map-filters.js'
 import SidePanel from '@/components/map/point-side-panel.js'
 import useEvent from '@/hook/use-event.js'
@@ -153,6 +154,9 @@ const Page = () => {
               <MenuItem value='vector-ign'>IGN vectoriel</MenuItem>
             </Select>
           </FormControl>
+        </Box>
+        <Box>
+          <Legend />
         </Box>
       </Box>
     </SidePanelLayout>

--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -110,7 +110,7 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint, style}
       maxWidth: 80,
       unit: 'metric'
     })
-    map.addControl(scale)
+    map.addControl(scale, 'bottom-right')
 
     mapRef.current = map
 

--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -16,9 +16,6 @@ import vector from './styles/vector.json'
 
 import {
   computeBestPopupAnchor,
-  eauSouterraine,
-  eauSurface,
-  createDonutChart,
   createUsagePieChart,
   createPointPrelevementFeatures
 } from '@/lib/points-prelevement.js'
@@ -35,14 +32,7 @@ function loadMap(map, points) {
   // On ajoute la source en ne gardant que les points filtrés
   map.addSource(SOURCE_ID, {
     type: 'geojson',
-    data: createPointPrelevementFeatures(points),
-    cluster: true,
-    clusterRadius: 80,
-    clusterProperties: {
-      // Comptage pour chaque type d'environnement
-      eauSurface: ['+', ['case', eauSurface, 1, 0]],
-      eauSouterraine: ['+', ['case', eauSouterraine, 1, 0]]
-    }
+    data: createPointPrelevementFeatures(points)
   })
 
   // Layer combiné affichant le nom et le typeMilieu (entre parenthèses sur deux lignes)
@@ -50,14 +40,10 @@ function loadMap(map, points) {
     id: 'points-prelevement-nom',
     type: 'symbol',
     source: SOURCE_ID,
-    filter: ['!=', 'cluster', true],
     layout: {
       'text-field': [
-        'concat',
-        ['get', 'nom'],
-        '\n(',
-        ['get', 'typeMilieu'],
-        ')'
+        'get',
+        'nom'
       ],
       'text-anchor': 'bottom',
       'text-offset': ['get', 'textOffset']
@@ -172,13 +158,11 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint, style}
     for (const feature of features) {
       const coords = feature.geometry.coordinates
       const props = feature.properties
-      const id = props.cluster ? props.cluster_id : props.id_point
+      const id = props.id_point
 
       let marker = markersCacheRef.current[id]
       if (!marker) {
-        const el = props.cluster
-          ? createDonutChart(props)
-          : createUsagePieChart(props)
+        const el = createUsagePieChart(props)
 
         if (!props.cluster && !el.dataset.eventsAttached) {
           el.dataset.eventsAttached = 'true'

--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -253,7 +253,16 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint, style}
     }
 
     if (selectedPoint) {
-      map.setLayoutProperty('points-prelevement-nom', 'text-size', 20)
+      map.setLayoutProperty(
+        'points-prelevement-nom',
+        'text-size',
+        [
+          'case',
+          ['==', ['get', 'id_point'], selectedPoint.id_point],
+          20,
+          16
+        ]
+      )
       map.setPaintProperty(
         'points-prelevement-nom',
         'text-halo-color',

--- a/src/components/map/legend-colors.js
+++ b/src/components/map/legend-colors.js
@@ -1,13 +1,12 @@
 export const legendColors = {
   usages: [
-    {text: 'Eau potable', color: 'deepskyblue'},
-    {text: 'Agriculture', color: 'lawngreen'},
-    {text: 'Camion citerne', color: 'grey'},
-    {text: 'Eau embouteillée', color: 'skyblue'},
-    {text: 'Hydroélectricité', color: 'steelblue'},
-    {text: 'Industrie', color: 'slategrey'},
-    {text: 'Non renseigné', color: 'lightgrey'},
-    {text: 'Thermalisme', color: 'lightseagreen'}
+    {text: 'Eau potable', color: '#007cbf'},
+    {text: 'Agriculture', color: '#00a6a6'},
+    {text: 'Camion citerne', color: '#8a2be2'},
+    {text: 'Eau embouteillée', color: '#ffa6c9'},
+    {text: 'Hydroélectricité', color: '#FFCC00'},
+    {text: 'Industrie', color: '#ff6347'},
+    {text: 'Non renseigné', color: '#ccc'}
   ],
   typesMilieu: [
     {text: 'Eau de surface', color: 'deepskyblue'},

--- a/src/components/map/legend.js
+++ b/src/components/map/legend.js
@@ -1,56 +1,45 @@
-import {Box, Checkbox} from '@mui/material'
+import {Box, useTheme} from '@mui/material'
 
 import {legendColors} from './legend-colors.js'
 
-const Bubble = ({color, text, isActive, onChange}) => (
+const Bubble = ({color, text}) => (
   <Box className='flex items-center justify-between gap-2'>
-    <Box className='flex items-center gap-2'>
-      <Box
-        sx={{
-          height: 15,
-          width: 15,
-          backgroundColor: color,
-          border: '1px solid black',
-          borderRadius: '50%'
-        }}
-      />
-      {text}
-    </Box>
-
-    <Checkbox checked={isActive} onChange={onChange} />
+    <Box
+      sx={{
+        height: 15,
+        width: 15,
+        backgroundColor: color,
+        border: '1px solid black',
+        borderRadius: '50%'
+      }}
+    />
+    {text}
   </Box>
 )
 
-const Legend = ({legend, activeFilters, setFilters}) => {
-  const {usages, typesMilieu} = legendColors
+const Legend = () => {
+  const {usages} = legendColors
+  const theme = useTheme()
 
   return (
-    <Box>
+    <Box
+      sx={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        p: 2,
+        backgroundColor: theme.palette.background.default
+      }}
+    >
       <Box>
-        {legend === 'usages' && (
-          usages.map(usage => (
-            <Box key={usage.text}>
-              <Bubble
-                color={usage.color}
-                text={usage.text}
-                isActive={!activeFilters.includes(usage.text)}
-                onChange={() => setFilters(usage.text)}
-              />
-            </Box>
-          ))
-        )}
-
-        {legend === 'milieux' && (
-          typesMilieu.map(type => (
+        {usages.map(usage => (
+          <Box key={usage.text}>
             <Bubble
-              key={type.text}
-              color={type.color}
-              text={type.text}
-              isActive={!activeFilters.includes(type.text)}
-              onChange={() => setFilters(type.text)}
+              color={usage.color}
+              text={usage.text}
             />
-          ))
-        )}
+          </Box>
+        ))}
       </Box>
     </Box>
   )

--- a/src/lib/points-prelevement.js
+++ b/src/lib/points-prelevement.js
@@ -33,10 +33,6 @@ export function extractTypeMilieu(points) {
   return [...typeMilieuSet]
 }
 
-// Filters for classifying points by type of environment
-export const eauSurface = ['==', ['get', 'typeMilieu'], 'Eau de surface']
-export const eauSouterraine = ['==', ['get', 'typeMilieu'], 'Eau souterraine']
-
 export const colors = ['#007cbf', '#00a6a6', '#f0f0f0']
 
 export function createPointPrelevementFeatures(points) {
@@ -48,91 +44,10 @@ export function createPointPrelevementFeatures(points) {
       id: point.id_point,
       properties: {
         ...point,
-        textOffset: [0, 2.5 + (0.07 * Math.min(point.nom?.length || 0, 50))]
+        textOffset: [0, 1.5 + (0.07 * Math.min(point.nom?.length || 0, 50))]
       }
     }))
   }
-}
-
-// Code for creating an SVG donut chart from feature properties
-export function createDonutChart(props) {
-  const offsets = []
-  const counts = [
-    props.eauSurface,
-    props.eauSouterraine
-  ]
-  let total = 0
-  for (const count of counts) {
-    offsets.push(total)
-    total += count
-  }
-
-  let fontSize
-  if (total >= 1000) {
-    fontSize = 22
-  } else if (total >= 100) {
-    fontSize = 20
-  } else if (total >= 10) {
-    fontSize = 18
-  } else {
-    fontSize = 16
-  }
-
-  let r
-  if (total >= 1000) {
-    r = 50
-  } else if (total >= 100) {
-    r = 32
-  } else if (total >= 10) {
-    r = 24
-  } else {
-    r = 18
-  }
-
-  const r0 = Math.round(r * 0.6)
-  const w = r * 2
-
-  let html
-      = `<div><svg width="${
-        w
-      }" height="${
-        w
-      }" viewbox="0 0 ${
-        w
-      } ${
-        w
-      }" text-anchor="middle" style="font: ${
-        fontSize
-      }px sans-serif; display: block">`
-
-  for (const [i, count] of counts.entries()) {
-    html += donutSegment(
-      offsets[i] / total,
-      (offsets[i] + count) / total,
-      r,
-      r0,
-      colors[i]
-    )
-  }
-
-  html
-      += `<circle cx="${
-      r
-    }" cy="${
-      r
-    }" r="${
-      r0
-    }" fill="white" /><text dominant-baseline="central" transform="translate(${
-      r
-    }, ${
-      r
-    })">${
-      total.toLocaleString()
-    }</text></svg></div>`
-
-  const el = document.createElement('div')
-  el.innerHTML = html
-  return el.firstChild
 }
 
 export function donutSegment(start, end, r, r0, color) {

--- a/src/lib/points-prelevement.js
+++ b/src/lib/points-prelevement.js
@@ -130,8 +130,6 @@ export function createUsagePieChart(props) {
 
   // Conteneur principal
   const container = document.createElement('div')
-  container.style.width = '24px'
-  container.style.height = '24px'
   container.style.display = 'block'
 
   // Prépare un <svg> centré sur (r, r)
@@ -139,11 +137,20 @@ export function createUsagePieChart(props) {
   const radius = 10
   const cx = radius
   const cy = radius
+  container.style.width = svgSize + 4
+  container.style.height = svgSize + 4
 
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  const borderCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+  borderCircle.setAttribute('cx', cx)
+  borderCircle.setAttribute('cy', cy)
+  borderCircle.setAttribute('r', radius + 2)
+  borderCircle.setAttribute('fill', 'white')
+
+  svg.append(borderCircle)
   svg.setAttribute('width', String(svgSize))
   svg.setAttribute('height', String(svgSize))
-  svg.setAttribute('viewBox', `0 0 ${svgSize} ${svgSize}`)
+  svg.setAttribute('viewBox', `-2 -2 ${svgSize} ${svgSize}`)
   svg.style.display = 'block'
 
   // Ajoute le <svg> au conteneur


### PR DESCRIPTION
Cette PR supprime les "clusters" de la carte pour des raisons pratiques.

- Suppression des clusters
- Correction de la taille du texte sur la carte
- Ajout d'un liseré blanc autour des marqueurs
- Retour de la légende de couleur

## Captures

### Avant

![image](https://github.com/user-attachments/assets/12a36dc7-8d9a-4693-8e9f-ce7ff6a5e2aa)

### Après

![image](https://github.com/user-attachments/assets/74fc5e14-fb9a-4a40-9515-dcfa50c61a76)
