### PR TITLE
Corrige le filtre type de milieu

### DIFF
--- a/src/lib/points-prelevement.js
+++ b/src/lib/points-prelevement.js
@@ -27,8 +27,8 @@ export function extractUsages(points) {
 export function extractTypeMilieu(points) {
   const typeMilieuSet = new Set()
   for (const point of points) {
-    if (point.typeMilieu) { // Filter undefined values
-      typeMilieuSet.add(point.typeMilieu)
+    if (point.type_milieu) { // Filter undefined values
+      typeMilieuSet.add(point.type_milieu)
     }
   }
 


### PR DESCRIPTION
Le filtre "type de milieu" sur la carte ne fonctionnait plus suite à un oubli dans la PR #21 