### PR TITLE
Mise à jour corrective du tableau règles

### DIFF
--- a/src/components/regles.js
+++ b/src/components/regles.js
@@ -2,6 +2,7 @@
 
 import {Box} from '@mui/material'
 import {DataGrid} from '@mui/x-data-grid'
+import {frFR} from '@mui/x-data-grid/locales'
 
 const API_URL = process.env.NEXT_PUBLIC_STORAGE_URL
 
@@ -59,6 +60,7 @@ const Regles = ({regles}) => (
     <DataGrid
       disableSelectionOnClick
       hideFooterPagination
+      localeText={frFR.components.MuiDataGrid.defaultProps.localeText}
       rows={regles}
       columns={reglesColumns}
       getRowId={row => row.id_regle}

--- a/src/components/regles.js
+++ b/src/components/regles.js
@@ -1,7 +1,7 @@
 'use client'
 
 import {Box} from '@mui/material'
-import {DataGrid} from '@mui/x-data-grid'
+import {DataGrid, GridToolbar} from '@mui/x-data-grid'
 import {frFR} from '@mui/x-data-grid/locales'
 
 const API_URL = process.env.NEXT_PUBLIC_STORAGE_URL
@@ -60,6 +60,7 @@ const Regles = ({regles}) => (
     <DataGrid
       disableSelectionOnClick
       hideFooterPagination
+      slots={{toolbar: GridToolbar}}
       localeText={frFR.components.MuiDataGrid.defaultProps.localeText}
       rows={regles}
       columns={reglesColumns}

--- a/src/components/regles.js
+++ b/src/components/regles.js
@@ -1,8 +1,10 @@
 'use client'
 
-import {Box} from '@mui/material'
+import {Box, Tooltip} from '@mui/material'
 import {DataGrid, GridToolbar} from '@mui/x-data-grid'
 import {frFR} from '@mui/x-data-grid/locales'
+
+import formatDate, {formatPeriodeDate} from '@/lib/format-date.js'
 
 const API_URL = process.env.NEXT_PUBLIC_STORAGE_URL
 
@@ -32,14 +34,60 @@ const reglesColumns = [
     headerName: 'Contrainte',
     width: 100
   },
-  {field: 'debut_periode', headerName: 'Début période', width: 110},
-  {field: 'fin_periode', headerName: 'Fin période', width: 110},
-  {field: 'debut_validite', headerName: 'Début validité', width: 110},
-  {field: 'fin_validite', headerName: 'Fin validité', width: 110},
+  {
+    field: 'debut_validite',
+    headerName: 'Début validité',
+    width: 110,
+    renderCell(params) {
+      return (
+        formatDate(params.row.debut_validite)
+      )
+    }
+  },
+  {
+    field: 'fin_validite',
+    headerName: 'Fin validité',
+    width: 110,
+    renderCell(params) {
+      return (
+        formatDate(params.row.fin_validite)
+      )
+    }
+  },
+  {
+    field: 'debut_periode',
+    headerName: 'Début période',
+    width: 110,
+    renderCell(params) {
+      return (
+        <Tooltip
+          arrow
+          title='Début de période d’application de la règle, lorsque celle-ci ne s’applique que sur une période de l’année'
+        >
+          {formatPeriodeDate(params.row.debut_periode)}
+        </Tooltip>
+      )
+    }
+  },
+  {
+    field: 'fin_periode',
+    headerName: 'Fin période',
+    width: 110,
+    renderCell(params) {
+      return (
+        <Tooltip
+          arrow
+          title='Fin de période d’application de la règle, lorsque celle-ci ne s’applique que sur une période de l’année'
+        >
+          {formatPeriodeDate(params.row.fin_periode)}
+        </Tooltip>
+      )
+    }
+  },
   {
     field: 'document',
     headerName: 'Document',
-    width: 130,
+    width: 250,
     renderCell(params) {
       return (
         <a
@@ -52,7 +100,7 @@ const reglesColumns = [
       )
     }
   },
-  {field: 'remarque', headerName: 'Remarque', width: 250}
+  {field: 'remarque', headerName: 'Remarque', width: 400}
 ]
 
 const Regles = ({regles}) => (

--- a/src/lib/format-date.js
+++ b/src/lib/format-date.js
@@ -1,4 +1,5 @@
 import {format} from 'date-fns'
+import {fr} from 'date-fns/locale'
 
 function formatDate(date) {
   if (!date) {
@@ -6,6 +7,14 @@ function formatDate(date) {
   }
 
   return format(date, 'dd/MM/yyyy')
+}
+
+export function formatPeriodeDate(date) {
+  if (!date) {
+    return null
+  }
+
+  return format(date, 'd MMMM', {locale: fr})
 }
 
 export default formatDate

--- a/src/lib/format-date.js
+++ b/src/lib/format-date.js
@@ -1,6 +1,14 @@
 import {format} from 'date-fns'
 import {fr} from 'date-fns/locale'
 
+function transformFrenchFirst(day) {
+  if (day === 1) {
+    return '1er'
+  }
+
+  return day
+}
+
 function formatDate(date) {
   if (!date) {
     return null
@@ -9,12 +17,15 @@ function formatDate(date) {
   return format(date, 'dd/MM/yyyy')
 }
 
-export function formatPeriodeDate(date) {
-  if (!date) {
+export function formatPeriodeDate(dateString) {
+  if (!dateString) {
     return null
   }
 
-  return format(date, 'd MMMM', {locale: fr})
+  const date = new Date(dateString)
+  const day = date.getDate()
+
+  return `${transformFrenchFirst(day)} ${format(date, 'MMMM', {locale: fr})}`
 }
 
 export default formatDate


### PR DESCRIPTION
Suite aux retours de Valentin, quelques modifications ont été apportées au tableau d'affichage des règles : 

- Traduction des filtres dans l'en-tête du tableau
- Déplacement des champs `Début période` et `Fin période` après le champ `Fin de validité`
- Ajout d'une infobulle sur les champs `Début période` et `Fin période`
- Modification de l'affichage des dates dans ces deux champs
- Utilisation de `formatDate` sur tous les autres champs date
- Léger élargissement des case du tableau pour un meilleur affichage
- Ajout de la `Toolbox` du tableau pour pouvoir exporter les données