### PR TITLE
Corrections dans points-prélèvement/exploitations

### DIFF
--- a/src/components/document.js
+++ b/src/components/document.js
@@ -14,10 +14,10 @@ const Document = ({document}) => (
       justifyContent: 'space-between'
     }}
   >
-    <Box sx={{display: 'flex', flexDirection: 'column', p: 1}}>
+    <Box sx={{display: 'flex', flexDirection: 'column', p: 2}}>
       <Typography sx={{pr: 1}}>
         <Article sx={{pr: 1, verticalAlign: 'bottom'}} />
-        {document.nature} - {document.reference} du {formatDate(document.date_signature)}
+        {document.nature} {document.reference ? `- n°${document.reference}` : ''} du {formatDate(document.date_signature)}
       </Typography>
       {document.date_fin_validite && (
         <Typography variant='caption' sx={{pl: 2}}>

--- a/src/components/document.js
+++ b/src/components/document.js
@@ -25,10 +25,10 @@ const Document = ({document}) => (
         </Typography>
       )}
       {document.remarque && (
-        <Typography>Remarque : {document.remarque}</Typography>
+        <Typography className='pl-3 pt-2'><b>Remarque :</b> <i>{document.remarque}</i></Typography>
       )}
     </Box>
-    <Typography variant='caption'>
+    <Typography variant='caption' className='p-5'>
       <a
         href={`${API_URL}/document/${document.nom_fichier}`}
         target='_blank'

--- a/src/components/points-prelevement/point-exploitations.js
+++ b/src/components/points-prelevement/point-exploitations.js
@@ -98,10 +98,7 @@ const PointExploitations = ({pointPrelevement}) => {
                   justifyContent: 'space-between'
                 }}
               >
-                <LabelValue label='Statut' value={exploitation.statut} />
                 <LabelValue label='Usage' value={exploitation.usage} />
-                <LabelValue label='Date de début' value={formatDate(exploitation.date_debut)} />
-                <LabelValue label='Date de fin' value={formatDate(exploitation.date_fin) || ''} />
                 <LabelValue label='Raison abandon' value={exploitation.raison_abandon} />
                 <LabelValue label='Remarque' value={exploitation.remarque} />
               </Grid2>

--- a/src/components/points-prelevement/point-exploitations.js
+++ b/src/components/points-prelevement/point-exploitations.js
@@ -72,13 +72,14 @@ const PointExploitations = ({pointPrelevement}) => {
               <div className='flex gap-1 sm:gap-5 flex-col sm:flex-row justify-between items-start sm:items-center w-full'>
                 <div className='flex-1 flex gap-1'>
                   <AccountCircle />
-                  <Typography className='pr-5'>
+                  <Typography className='px-2'>
                     <b>
                       {exploitation.beneficiaire.nom
                         || exploitation.beneficiaire.raison_sociale
                         || exploitation.beneficiaire.sigle}
                     </b>
                   </Typography>
+                  ({exploitation.usage})
                 </div>
                 <div className='flex-1 flex gap-2 pr-0 sm:pr-3 flex-col sm:flex-row justify-end items-start sm:items-center'>
                   <Typography className='px-0 sm:px-2'>
@@ -98,7 +99,6 @@ const PointExploitations = ({pointPrelevement}) => {
                   justifyContent: 'space-between'
                 }}
               >
-                <LabelValue label='Usage' value={exploitation.usage} />
                 <LabelValue label='Raison abandon' value={exploitation.raison_abandon} />
                 <LabelValue label='Remarque' value={exploitation.remarque} />
               </Grid2>

--- a/src/components/points-prelevement/point-exploitations.js
+++ b/src/components/points-prelevement/point-exploitations.js
@@ -81,7 +81,6 @@ const PointExploitations = ({pointPrelevement}) => {
                   </Typography>
                 </div>
                 <div className='flex-1 flex gap-2 pr-0 sm:pr-3 flex-col sm:flex-row justify-end items-start sm:items-center'>
-                  <b>#{exploitation.id_exploitation}</b>
                   <Typography className='px-0 sm:px-2'>
                     <i>
                       ({formatDate(exploitation.date_debut)} / {formatDate(exploitation.date_fin) || 'en cours '})


### PR DESCRIPTION
Modifications suite aux retours de Valentin : 

- Suppression de l'id de l'exploitation dans le titre
- Suppression des informations en doublons
- Déplacement de "usage" dans le titre
- Mise en valeur des remarques lorsqu'il y en a
- Ajout de "n°" devant la référence du document lorsqu'elle est présente

