### PR TITLE
Corrige l'exportation du tableau "règles"

### DIFF
--- a/src/components/regles.js
+++ b/src/components/regles.js
@@ -57,7 +57,7 @@ const reglesColumns = [
   {
     field: 'debut_periode',
     headerName: 'Début période',
-    width: 110,
+    width: 120,
     renderCell(params) {
       return (
         <Tooltip
@@ -72,7 +72,7 @@ const reglesColumns = [
   {
     field: 'fin_periode',
     headerName: 'Fin période',
-    width: 110,
+    width: 120,
     renderCell(params) {
       return (
         <Tooltip

--- a/src/components/regles.js
+++ b/src/components/regles.js
@@ -98,7 +98,8 @@ const reglesColumns = [
           {params.row.document.nature}
         </a>
       )
-    }
+    },
+    valueGetter: params => params ? params.nature : ''
   },
   {field: 'remarque', headerName: 'Remarque', width: 400}
 ]


### PR DESCRIPTION
Cette PR corrige l'exportation des données du tableau "règles" : 

Le champ "document" étant un lien, il était affiché en `[object Object]` .
J'ai ajouté un `valueGetter` pour récupérer la bonne information.

J'en ai profité pour agrandir légèrement les cases "période" qui étaient tronquées.