### PR TITLE
Détail point-prélèvement : Bouton retour et query

### DIFF
--- a/src/app/points-prelevement/[id]/[tab]/page.js
+++ b/src/app/points-prelevement/[id]/[tab]/page.js
@@ -1,3 +1,6 @@
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import Link from 'next/link'
+
 import {
   getBeneficiaire,
   getBnpe,
@@ -33,24 +36,30 @@ const Page = async ({params}) => {
   pointPrelevement.exploitations = exploitationsWithBeneficiaires
 
   return (
-    <div className='fr-container mt-4'>
-      <PointTabs selectedTab={selectedTab} />
-      {selectedTab === 'identification' && (
-        <PointIdentification
-          pointPrelevement={pointPrelevement}
-        />
-      )}
-      {selectedTab === 'localisation' && (
-        <PointLocalistation
-          pointPrelevement={pointPrelevement}
-        />
-      )}
-      {selectedTab === 'exploitations' && (
-        <PointExploitations
-          pointPrelevement={pointPrelevement}
-        />
-      )}
-    </div>
+    <>
+      <div className='pt-5 pl-5'>
+        <ArrowBackIcon className='pr-1' />
+        <Link href={`/points-prelevement?point-prelevement=${id}`}>Retour</Link>
+      </div>
+      <div className='fr-container mt-4'>
+        <PointTabs selectedTab={selectedTab} />
+        {selectedTab === 'identification' && (
+          <PointIdentification
+            pointPrelevement={pointPrelevement}
+          />
+        )}
+        {selectedTab === 'localisation' && (
+          <PointLocalistation
+            pointPrelevement={pointPrelevement}
+          />
+        )}
+        {selectedTab === 'exploitations' && (
+          <PointExploitations
+            pointPrelevement={pointPrelevement}
+          />
+        )}
+      </div>
+    </>
   )
 }
 

--- a/src/app/points-prelevement/page.js
+++ b/src/app/points-prelevement/page.js
@@ -13,7 +13,7 @@ import {
   useTheme
 } from '@mui/material'
 import {deburr} from 'lodash-es'
-import {useSearchParams} from 'next/navigation'
+import {useRouter, useSearchParams} from 'next/navigation'
 
 import {getPointsPrelevement} from '@/app/api/points-prelevement.js'
 import SidePanelLayout from '@/components/layout/side-panel.js'
@@ -30,6 +30,7 @@ import {extractTypeMilieu, extractUsages} from '@/lib/points-prelevement.js'
 const Page = () => {
   const theme = useTheme()
   const searchParams = useSearchParams()
+  const router = useRouter()
   const pointId = searchParams.get('point-prelevement')
   // État pour les données
   const [points, setPoints] = useState([])
@@ -76,6 +77,7 @@ const Page = () => {
     const point = points.find(p => p.id_point === pointId)
     setSelectedPoint(point)
     setExpanded(true)
+    router.push(`?point-prelevement=${point.id_point}`)
   })
 
   const handleFilter = useCallback(newFilters => {

--- a/src/app/points-prelevement/page.js
+++ b/src/app/points-prelevement/page.js
@@ -13,6 +13,7 @@ import {
   useTheme
 } from '@mui/material'
 import {deburr} from 'lodash-es'
+import {useSearchParams} from 'next/navigation'
 
 import {getPointsPrelevement} from '@/app/api/points-prelevement.js'
 import SidePanelLayout from '@/components/layout/side-panel.js'
@@ -28,6 +29,8 @@ import {extractTypeMilieu, extractUsages} from '@/lib/points-prelevement.js'
 
 const Page = () => {
   const theme = useTheme()
+  const searchParams = useSearchParams()
+  const pointId = searchParams.get('point-prelevement')
   // État pour les données
   const [points, setPoints] = useState([])
   const [loading, setLoading] = useState(true)
@@ -107,6 +110,14 @@ const Page = () => {
 
     setFilteredPoints(filtered.map(point => point.id_point))
   }, [filters, points])
+
+  useEffect(() => {
+    if (pointId) {
+      const point = points.find(point => pointId === point.id_point)
+
+      setSelectedPoint(point)
+    }
+  }, [pointId, points])
 
   return (
     <SidePanelLayout


### PR DESCRIPTION
Cette PR ajoute la gestion de la query sur la page `/points-prelevement`.
La sélection d'un point pousse l'id dans l'URL de la page, par exemple : `/points-prelevement?point-prelevement=167`

Elle ajoute également un lien "retour" sur la page `/points-prelevement/{id}` permettant de conserver le point sélectionné précédemment.