### PR TITLE
Correction de `points-prelevement/{id}/localisation`

### DIFF
--- a/src/components/points-prelevement/point-localisation.js
+++ b/src/components/points-prelevement/point-localisation.js
@@ -46,7 +46,7 @@ const PointLocalistation = ({pointPrelevement}) => (
           />
         )}
         <LabelValue label='Cours d’eau (BD Carthage)' value={pointPrelevement.bvBdCarthage?.toponyme_t} />
-        <LabelValue label='Cours d’eau' value={pointPrelevement.cours_eau} />
+        <LabelValue label='Cours d’eau indiqué dans l’autorisation' value={pointPrelevement.cours_eau} />
         <LabelValue label='Zone de répartition des eaux' value={pointPrelevement.zre ? 'oui' : null} />
         <LabelValue label='Réservoir biologique' value={pointPrelevement.reservoir_biologique ? 'oui' : null} />
       </>

--- a/src/components/points-prelevement/point-localisation.js
+++ b/src/components/points-prelevement/point-localisation.js
@@ -39,11 +39,13 @@ const PointLocalistation = ({pointPrelevement}) => (
     )}
     {pointPrelevement.type_milieu === 'Eau de surface' && (
       <>
-        <LabelValue
-          label='Masse d’eau cours d’eau (DCE)'
-          value={`${pointPrelevement.meContinentalesBv.code_dce} - ${pointPrelevement.meContinentalesBv.nom}`}
-        />
-        <LabelValue label='Code bdCarthage' value={pointPrelevement.code_bv_bdcarthage} />
+        {pointPrelevement.meContinentalesBv && (
+          <LabelValue
+            label='Masse d’eau cours d’eau (DCE)'
+            value={`${pointPrelevement.meContinentalesBv.code_dce} - ${pointPrelevement.meContinentalesBv.nom}`}
+          />
+        )}
+        <LabelValue label='Cours d’eau (BD Carthage)' value={pointPrelevement.bvBdCarthage?.toponyme_t} />
         <LabelValue label='Cours d’eau' value={pointPrelevement.cours_eau} />
         <LabelValue label='ZRE' value={pointPrelevement.zre} />
         <LabelValue label='Réservoir biologique' value={pointPrelevement.reservoir_bio} />

--- a/src/components/points-prelevement/point-localisation.js
+++ b/src/components/points-prelevement/point-localisation.js
@@ -33,7 +33,7 @@ const PointLocalistation = ({pointPrelevement}) => (
           </Box>
         )}
         <LabelValue label='Profondeur' value={pointPrelevement.profondeur} />
-        <LabelValue label='Meso' value={pointPrelevement.code_meso} />
+        <LabelValue label='Masse d’eau souterraine (DCE)' value={pointPrelevement.meso.nom_provis} />
       </>
     )}
     {pointPrelevement.type_milieu === 'Eau de surface' && (

--- a/src/components/points-prelevement/point-localisation.js
+++ b/src/components/points-prelevement/point-localisation.js
@@ -47,8 +47,8 @@ const PointLocalistation = ({pointPrelevement}) => (
         )}
         <LabelValue label='Cours d’eau (BD Carthage)' value={pointPrelevement.bvBdCarthage?.toponyme_t} />
         <LabelValue label='Cours d’eau' value={pointPrelevement.cours_eau} />
-        <LabelValue label='ZRE' value={pointPrelevement.zre} />
-        <LabelValue label='Réservoir biologique' value={pointPrelevement.reservoir_bio} />
+        <LabelValue label='Zone de répartition des eaux' value={pointPrelevement.zre ? 'oui' : null} />
+        <LabelValue label='Réservoir biologique' value={pointPrelevement.reservoir_biologique ? 'oui' : null} />
       </>
     )}
   </Box>

--- a/src/components/points-prelevement/point-localisation.js
+++ b/src/components/points-prelevement/point-localisation.js
@@ -32,8 +32,11 @@ const PointLocalistation = ({pointPrelevement}) => (
     )}
     {pointPrelevement.type_milieu === 'Eau de surface' && (
       <>
+        <LabelValue
+          label='Masse d’eau cours d’eau (DCE)'
+          value={`${pointPrelevement.meContinentalesBv.code_dce} - ${pointPrelevement.meContinentalesBv.nom}`}
+        />
         <LabelValue label='Code bdCarthage' value={pointPrelevement.code_bv_bdcarthage} />
-        <LabelValue label='Code me continental' value={pointPrelevement.code_me_continental_bv} />
         <LabelValue label='Cours d’eau' value={pointPrelevement.cours_eau} />
         <LabelValue label='ZRE' value={pointPrelevement.zre} />
         <LabelValue label='Réservoir biologique' value={pointPrelevement.reservoir_bio} />

--- a/src/components/points-prelevement/point-localisation.js
+++ b/src/components/points-prelevement/point-localisation.js
@@ -26,6 +26,12 @@ const PointLocalistation = ({pointPrelevement}) => (
     )}
     {pointPrelevement.type_milieu === 'Eau souterraine' && (
       <>
+        {pointPrelevement.profondeur && (
+          <Box>
+            <b>Profondeur</b>
+            <i>{pointPrelevement.profondeur} m</i>
+          </Box>
+        )}
         <LabelValue label='Profondeur' value={pointPrelevement.profondeur} />
         <LabelValue label='Meso' value={pointPrelevement.code_meso} />
       </>

--- a/src/components/points-prelevement/point-localisation.js
+++ b/src/components/points-prelevement/point-localisation.js
@@ -34,6 +34,7 @@ const PointLocalistation = ({pointPrelevement}) => (
         )}
         <LabelValue label='Profondeur' value={pointPrelevement.profondeur} />
         <LabelValue label='Masse d’eau souterraine (DCE)' value={pointPrelevement.meso.nom_provis} />
+        <LabelValue label='Zone de répartition des eaux' value={pointPrelevement.zre ? 'oui' : null} />
       </>
     )}
     {pointPrelevement.type_milieu === 'Eau de surface' && (


### PR DESCRIPTION
Suite aux retours de Valentin, quelques modifications ont été apportées à l'onglet `localisation` :
- Modification du label et de la valeur pour `code_me_continentales_bv`
- Modification du label et de la valeur pour `bdCarthage`
- Modification du label et de la valeur pour `meso`
- Ajout de l'unité pour la profondeur
- Modification du champ `zre`
- Ajout du champ `cours_eau`

> ⚠️ Cette PR a besoin des nouvelles routes présentes dans [cette PR](https://github.com/MTES-MCT/prelevement-deau-back/pull/14)