### PR TITLE
Ajout de visualisation des volumes dans l'onglet exploitations

### DIFF
--- a/src/app/api/points-prelevement.js
+++ b/src/app/api/points-prelevement.js
@@ -102,3 +102,9 @@ export async function getStats() {
 
   return stats
 }
+
+export async function getVolumesExploitation(exploitationId) {
+  const response = await fetch(`${API_URL}/api/exploitations/${exploitationId}/volumes-preleves`)
+  const volumes = await response.json()
+  return volumes
+}

--- a/src/components/points-prelevement/point-exploitations.js
+++ b/src/components/points-prelevement/point-exploitations.js
@@ -40,6 +40,7 @@ const LabelValue = ({label, value}) => {
 
 const PointExploitations = ({pointPrelevement}) => {
   const [expanded, setExpanded] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
   const [exploitationsWithVolumes, setExploitationsWithVolumes] = useState([])
   const orderedExploitations = pointPrelevement.exploitations.sort((a, b) => {
     if (a.date_fin === undefined) {
@@ -59,13 +60,19 @@ const PointExploitations = ({pointPrelevement}) => {
 
   useEffect(() => {
     async function getVolumes() {
-      const promises = orderedExploitations.map(async exploitation => {
-        const volumes = await getVolumesExploitation(exploitation.id_exploitation)
-        return {...exploitation, volumes}
-      })
+      try {
+        setIsLoading(true)
+        const promises = orderedExploitations.map(async exploitation => {
+          const volumes = await getVolumesExploitation(exploitation.id_exploitation)
+          return {...exploitation, volumes}
+        })
 
-      const exploitationsWithVolumes = await Promise.all(promises)
-      setExploitationsWithVolumes([...exploitationsWithVolumes])
+        const exploitationsWithVolumes = await Promise.all(promises)
+        setExploitationsWithVolumes([...exploitationsWithVolumes])
+        setIsLoading(false)
+      } catch (error) {
+        console.error(error)
+      }
     }
 
     getVolumes()
@@ -112,7 +119,7 @@ const PointExploitations = ({pointPrelevement}) => {
             </AccordionSummary>
             <AccordionDetails>
               {volumes.valeurs.length > 0 && (
-                <VolumesChart volumes={volumes} />
+                <VolumesChart volumes={volumes} isLoading={isLoading} />
               )}
               <Grid2
                 container

--- a/src/components/points-prelevement/point-exploitations.js
+++ b/src/components/points-prelevement/point-exploitations.js
@@ -7,6 +7,7 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Alert,
   Chip,
   Divider,
   Grid2,
@@ -41,6 +42,7 @@ const LabelValue = ({label, value}) => {
 const PointExploitations = ({pointPrelevement}) => {
   const [expanded, setExpanded] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
   const [exploitationsWithVolumes, setExploitationsWithVolumes] = useState([])
   const orderedExploitations = pointPrelevement.exploitations.sort((a, b) => {
     if (a.date_fin === undefined) {
@@ -72,6 +74,7 @@ const PointExploitations = ({pointPrelevement}) => {
         setIsLoading(false)
       } catch (error) {
         console.error(error)
+        setError(error)
       }
     }
 
@@ -118,6 +121,9 @@ const PointExploitations = ({pointPrelevement}) => {
               </div>
             </AccordionSummary>
             <AccordionDetails>
+              {error && (
+                <Alert severity='error'>{error}</Alert>
+              )}
               {volumes.valeurs.length > 0 && (
                 <VolumesChart volumes={volumes} isLoading={isLoading} />
               )}

--- a/src/components/points-prelevement/point-exploitations.js
+++ b/src/components/points-prelevement/point-exploitations.js
@@ -1,6 +1,6 @@
 'use client'
 
-import {useState} from 'react'
+import {useEffect, useState} from 'react'
 
 import {AccountCircle, ExpandMore} from '@mui/icons-material'
 import {
@@ -14,7 +14,9 @@ import {
 } from '@mui/material'
 import {orderBy} from 'lodash-es'
 
+import {getVolumesExploitation} from '@/app/api/points-prelevement.js'
 import Document from '@/components/document.js'
+import VolumesChart from '@/components/points-prelevement/volumes-chart.js'
 import Regles from '@/components/regles.js'
 import formatDate from '@/lib/format-date.js'
 
@@ -38,6 +40,7 @@ const LabelValue = ({label, value}) => {
 
 const PointExploitations = ({pointPrelevement}) => {
   const [expanded, setExpanded] = useState(false)
+  const [exploitationsWithVolumes, setExploitationsWithVolumes] = useState([])
   const orderedExploitations = pointPrelevement.exploitations.sort((a, b) => {
     if (a.date_fin === undefined) {
       return -1
@@ -54,14 +57,30 @@ const PointExploitations = ({pointPrelevement}) => {
     setExpanded(isExpanded ? panel : false)
   }
 
+  useEffect(() => {
+    async function getVolumes() {
+      const promises = orderedExploitations.map(async exploitation => {
+        const volumes = await getVolumesExploitation(exploitation.id_exploitation)
+        return {...exploitation, volumes}
+      })
+
+      const exploitationsWithVolumes = await Promise.all(promises)
+      setExploitationsWithVolumes([...exploitationsWithVolumes])
+    }
+
+    getVolumes()
+  }, [orderedExploitations])
+
   return (
     <div className='m-0 p-0 sm:m-2 sm:p-3'>
-      {orderedExploitations.map(exploitation => {
+      {exploitationsWithVolumes.length > 0 && exploitationsWithVolumes.map(exploitation => {
         const documents = exploitation.documents.map(document => ({
           ...document,
           dateSignature: new Date(document.date_signature)
         }))
         const orderedDocuments = orderBy(documents, ['dateSignature'], ['desc'])
+        const {volumes} = exploitation
+
         return (
           <Accordion
             key={exploitation.id_exploitation}
@@ -92,6 +111,9 @@ const PointExploitations = ({pointPrelevement}) => {
               </div>
             </AccordionSummary>
             <AccordionDetails>
+              {volumes.valeurs.length > 0 && (
+                <VolumesChart volumes={volumes} />
+              )}
               <Grid2
                 container
                 sx={{

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -27,7 +27,9 @@ const VolumesChart = ({volumes, isLoading}) => {
       color: '#2563eb',
       showMark: true,
       area: false,
-      valueFormatter: value => `${Number.parseFloat(value).toLocaleString('fr-FR')} m³`
+      valueFormatter(value) {
+        return value === null ? 'Non renseigné' : `${Number.parseFloat(value).toLocaleString('fr-FR')} m³`
+      }
     },
     {
       data: exceededData.map(item => item.volume),

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -125,7 +125,7 @@ const VolumesChart = ({volumes, isLoading}) => {
       <div className='flex flex-columns justify-between'>
         <div className='mt-4 text-sm'>
           {volumes.volumeJournalierMax && (
-            <p><b>Volume journalier maximum : </b>{volumes?.volumeJournalierMax} m³</p>
+            <p><b>Volume journalier maximum par mois : </b>{volumes?.volumeJournalierMax} m³</p>
           )}
           <p>
             <b>Nombre de dépassements : </b> {nbDepassements} sur {nbValeursRenseignees} valeurs

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -2,6 +2,7 @@
 
 import {useState} from 'react'
 
+import {CircularProgress} from '@mui/material'
 import {
   LineChart,
   ChartsReferenceLine
@@ -9,7 +10,7 @@ import {
 import {format, parseISO} from 'date-fns'
 import {fr} from 'date-fns/locale'
 
-const VolumesChart = ({volumes}) => {
+const VolumesChart = ({volumes, isLoading}) => {
   const [showAll, setShowAll] = useState(false)
   const sortedData = [...volumes.valeurs].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
   const displayData = showAll ? sortedData : sortedData.slice(-12)
@@ -56,61 +57,65 @@ const VolumesChart = ({volumes}) => {
         </button>
       </div>
       <div className='h-[400px] w-full'>
-        <LineChart
-          series={series}
-          xAxis={[
-            {
-              data: xLabels,
-              scaleType: 'band',
-              valueFormatter: date => format(parseISO(date), 'dd/MM/yyyy', {locale: fr}),
-              tickLabelStyle: {
-                angle: 45,
-                textAnchor: 'start',
-                fontSize: 12
+        {isLoading ? (
+          <CircularProgress />
+        ) : (
+          <LineChart
+            series={series}
+            xAxis={[
+              {
+                data: xLabels,
+                scaleType: 'band',
+                valueFormatter: date => format(parseISO(date), 'dd/MM/yyyy', {locale: fr}),
+                tickLabelStyle: {
+                  angle: 45,
+                  textAnchor: 'start',
+                  fontSize: 12
+                }
               }
-            }
-          ]}
-          yAxis={[
-            {
-              min: 65,
-              max: Math.max(...volumeData, volumes.volumeJournalierMax || 0) + 5,
-              valueFormatter: volume => Number.parseFloat(volume).toLocaleString('fr-FR')
-            }
-          ]}
-          height={350}
-          margin={{
-            left: 60,
-            right: 20,
-            top: 20,
-            bottom: 70
-          }}
-          grid={{
-            vertical: true,
-            horizontal: true
-          }}
-          slotProps={{
-            legend: {
-              direction: 'row',
-              position: {vertical: 'top', horizontal: 'right'}
-            },
-            tooltip: {
-              filter: item => item.seriesId === 'series-0'
-            }
-          }}
-        >
-          {hasVolumeMax && (
-            <ChartsReferenceLine
-              y={volumes.volumeJournalierMax}
-              label={`Volume max: ${Number.parseFloat(volumes.volumeJournalierMax).toLocaleString('fr-FR')} m³`}
-              labelAlign='start'
-              lineStyle={{
-                stroke: '#ef4444',
-                strokeWidth: 2,
-                strokeDasharray: '5 5'
-              }}
-            />
-          )}
-        </LineChart>
+            ]}
+            yAxis={[
+              {
+                min: 65,
+                max: Math.max(...volumeData, volumes.volumeJournalierMax || 0) + 5,
+                valueFormatter: volume => Number.parseFloat(volume).toLocaleString('fr-FR')
+              }
+            ]}
+            height={350}
+            margin={{
+              left: 60,
+              right: 20,
+              top: 20,
+              bottom: 70
+            }}
+            grid={{
+              vertical: true,
+              horizontal: true
+            }}
+            slotProps={{
+              legend: {
+                direction: 'row',
+                position: {vertical: 'top', horizontal: 'right'}
+              },
+              tooltip: {
+                filter: item => item.seriesId === 'series-0'
+              }
+            }}
+          >
+            {hasVolumeMax && (
+              <ChartsReferenceLine
+                y={volumes.volumeJournalierMax}
+                label={`Volume max: ${Number.parseFloat(volumes.volumeJournalierMax).toLocaleString('fr-FR')} m³`}
+                labelAlign='start'
+                lineStyle={{
+                  stroke: '#ef4444',
+                  strokeWidth: 2,
+                  strokeDasharray: '5 5'
+                }}
+              />
+            )}
+          </LineChart>
+        )}
       </div>
       <div className='flex flex-columns justify-between'>
         <div className='mt-4 text-sm'>

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -31,7 +31,7 @@ const VolumesChart = ({volumes, isLoading}) => {
     },
     {
       data: exceededData.map(item => item.volume),
-      color: 'rgb(239, 68, 68)',
+      color: '#ef4444',
       showMark: true,
       area: false,
       line: true,

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -43,7 +43,7 @@ const VolumesChart = ({volumes, isLoading}) => {
     }
   ]
 
-  const hasVolumeMax = volumes.volumeJournalierMax !== null
+  const hasVolumeMax = volumes.volumeJournalierMax
   const nbValeursRenseignees = showAll ? volumes.nbValeursRenseignees : displayData.length
   const nbDepassements = showAll ? volumes.nbDepassements : displayData.filter(v => v.depassement).length
 
@@ -124,8 +124,8 @@ const VolumesChart = ({volumes, isLoading}) => {
       </div>
       <div className='flex flex-columns justify-between'>
         <div className='mt-4 text-sm'>
-          {volumes.volumeJournalierMax && (
-            <p><b>Volume journalier maximum par mois : </b>{volumes?.volumeJournalierMax} m³</p>
+          {hasVolumeMax && (
+            <p><b>Volume journalier maximum par mois : </b>{volumes.volumeJournalierMax} m³</p>
           )}
           <p>
             <b>Nombre de dépassements : </b> {nbDepassements} sur {nbValeursRenseignees} valeurs

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -2,6 +2,7 @@
 
 import {useState} from 'react'
 
+import {fr as frColors} from '@codegouvfr/react-dsfr'
 import {CircularProgress} from '@mui/material'
 import {
   LineChart,
@@ -24,7 +25,7 @@ const VolumesChart = ({volumes, isLoading}) => {
   const series = [
     {
       data: displayData.map(item => item.volume),
-      color: '#2563eb',
+      color: frColors.colors.decisions.artwork.major.blueFrance.active,
       showMark: true,
       area: false,
       valueFormatter(value) {
@@ -33,7 +34,7 @@ const VolumesChart = ({volumes, isLoading}) => {
     },
     {
       data: exceededData.map(item => item.volume),
-      color: '#ef4444',
+      color: frColors.colors.decisions.artwork.major.redMarianne.active,
       showMark: true,
       area: false,
       line: true,
@@ -112,7 +113,7 @@ const VolumesChart = ({volumes, isLoading}) => {
                 label={`Volume max: ${Number.parseFloat(volumes.volumeJournalierMax).toLocaleString('fr-FR')} m³`}
                 labelAlign='start'
                 lineStyle={{
-                  stroke: '#ef4444',
+                  stroke: frColors.colors.decisions.artwork.major.redMarianne.default,
                   strokeWidth: 2,
                   strokeDasharray: '5 5'
                 }}

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -41,6 +41,8 @@ const VolumesChart = ({volumes, isLoading}) => {
   ]
 
   const hasVolumeMax = volumes.volumeJournalierMax !== null
+  const nbValeursRenseignees = showAll ? volumes.nbValeursRenseignees : displayData.length
+  const nbDepassements = showAll ? volumes.nbDepassements : displayData.filter(v => v.depassement).length
 
   return (
     <div className='w-full border-[1px] p-3'>
@@ -123,7 +125,7 @@ const VolumesChart = ({volumes, isLoading}) => {
             <p><b>Volume journalier maximum : </b>{volumes?.volumeJournalierMax} m³</p>
           )}
           <p>
-            <b>Nombre de dépassements : </b> {volumes.nbDepassements || 'non renseigné'} sur {volumes.nbValeursRenseignees} valeurs
+            <b>Nombre de dépassements : </b> {nbDepassements} sur {nbValeursRenseignees} valeurs
           </p>
         </div>
       </div>

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -26,7 +26,7 @@ const VolumesChart = ({volumes}) => {
       color: '#2563eb',
       showMark: true,
       area: false,
-      valueFormatter: value => `${value} m³`
+      valueFormatter: value => `${Number.parseFloat(value).toLocaleString('fr-FR')} m³`
     },
     {
       data: exceededData.map(item => item.volume),
@@ -72,7 +72,8 @@ const VolumesChart = ({volumes}) => {
           yAxis={[
             {
               min: 65,
-              max: Math.max(...volumeData, volumes.volumeJournalierMax || 0) + 5
+              max: Math.max(...volumeData, volumes.volumeJournalierMax || 0) + 5,
+              valueFormatter: volume => Number.parseFloat(volume).toLocaleString('fr-FR')
             }
           ]}
           height={350}

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -100,7 +100,7 @@ const VolumesChart = ({volumes}) => {
           {hasVolumeMax && (
             <ChartsReferenceLine
               y={volumes.volumeJournalierMax}
-              label={`Volume max: ${volumes.volumeJournalierMax} m³`}
+              label={`Volume max: ${Number.parseFloat(volumes.volumeJournalierMax).toLocaleString('fr-FR')} m³`}
               labelAlign='start'
               lineStyle={{
                 stroke: '#ef4444',

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -28,7 +28,7 @@ const VolumesChart = ({volumes, isLoading}) => {
       showMark: true,
       area: false,
       valueFormatter(value) {
-        return value === null ? 'Non renseigné' : `${Number.parseFloat(value).toLocaleString('fr-FR')} m³`
+        return value ? `${Number.parseFloat(value).toLocaleString('fr-FR')} m³` : 'Non renseigné'
       }
     },
     {

--- a/src/components/points-prelevement/volumes-chart.js
+++ b/src/components/points-prelevement/volumes-chart.js
@@ -34,6 +34,7 @@ const VolumesChart = ({volumes}) => {
       showMark: true,
       area: false,
       line: true,
+      // Masque la valeur affichée dans le tooltip, valeur déjà affichée avec la première série.
       valueFormatter: () => null
     }
   ]


### PR DESCRIPTION
Cette PR ajoute un graphique permettant de visualiser les volumes prélevés ainsi que les limites.

## Captures : 

![image](https://github.com/user-attachments/assets/57f78665-c57d-4dcf-9a65-2fa657c0a89a)

![image](https://github.com/user-attachments/assets/f4bacd58-ba1f-4745-b523-c4c3aa1c1c8e)

![image](https://github.com/user-attachments/assets/b9fd54bd-fc5b-4467-9359-c796a00e0b91)
