### PR TITLE
Correction des graphiques "Exploitations"

### DIFF
--- a/src/components/prelevements/volumes-chart.js
+++ b/src/components/prelevements/volumes-chart.js
@@ -8,13 +8,18 @@ import {
   LineChart,
   ChartsReferenceLine
 } from '@mui/x-charts'
-import {format, parseISO} from 'date-fns'
+import {format, parseISO, subMonths} from 'date-fns'
 import {fr} from 'date-fns/locale'
 
 const VolumesChart = ({volumes, isLoading}) => {
   const [showAll, setShowAll] = useState(false)
+
+  const mostRecentDate = new Date(Math.max(...volumes.valeurs.map(item => new Date(item.date).getTime())))
+  const twelveMonthsAgoFromRecent = subMonths(mostRecentDate, 12)
   const sortedData = [...volumes.valeurs].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-  const displayData = showAll ? sortedData : sortedData.slice(-12)
+  const lastTwelveMonthsData = sortedData.filter(item => new Date(item.date) >= twelveMonthsAgoFromRecent)
+  const displayData = showAll ? sortedData : lastTwelveMonthsData
+
   const xLabels = displayData.map(item => item.date)
   const volumeData = displayData.map(item => item.volume)
   const exceededData = displayData.map(item => ({


### PR DESCRIPTION
La fonction pour limiter l'affichage des volumes affichait les douze dernières valeurs.
Or, il peut arriver que les volumes soient sur des fréquences hebdomadaires. Dans ce cas, on affichait donc les douze derniers jours au lieu des douze derniers mois.

## Captures
### Avant : 

![image](https://github.com/user-attachments/assets/a0497948-838c-43a2-b33d-89a56bc0e166)

![image](https://github.com/user-attachments/assets/33132886-a81a-4178-a8a7-fa65ae0dd2bc)

### Après : 

![image](https://github.com/user-attachments/assets/87861e7c-0bf9-4cbe-bb99-1a7b03147620)

![image](https://github.com/user-attachments/assets/c27f9695-3d98-4d49-a0e9-8fdc06b9827d)


>[!NOTE]
> Après dicussion, je mets cette PR de côté.
> Il faut réfléchir à une façon intelligente d'afficher les volumes lorsqu'ils ont plusieurs fréquence (journalier/mensuel)
> __Exemple :__ 
> ![Screenshot 2025-03-20 at 11-38-33 Suivi des prélèvements d’eau](https://github.com/user-attachments/assets/b821b070-25b6-4846-80f5-026d50124ea8)
