### PR TITLE
Affiche la civilité et le prénom dans la liste des exploitations

### DIFF
--- a/src/components/prelevements/point-exploitations.js
+++ b/src/components/prelevements/point-exploitations.js
@@ -39,6 +39,14 @@ const LabelValue = ({label, value}) => {
   }
 }
 
+function getBeneficiaireInfo(beneficiaire) {
+  if (beneficiaire.nom) {
+    return `${beneficiaire.civilite || ''} ${beneficiaire.nom} ${beneficiaire.prenom || ''}`
+  }
+
+  return beneficiaire.raison_sociale || beneficiaire.sigle
+}
+
 const PointExploitations = ({pointPrelevement}) => {
   const [expanded, setExpanded] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -118,12 +126,7 @@ const PointExploitations = ({pointPrelevement}) => {
                 <div className='flex-1 flex gap-1'>
                   <AccountCircle />
                   <Typography className='px-2'>
-                    <b>
-                      {exploitation.beneficiaire.nom
-                        ? `${exploitation.beneficiaire?.civilite || ''} ${exploitation.beneficiaire.nom} ${exploitation.beneficiaire?.prenom || ''}`
-                        : (exploitation.beneficiaire.raison_sociale
-                        || exploitation.beneficiaire.sigle)}
-                    </b>
+                    <b>{getBeneficiaireInfo(exploitation.beneficiaire)}</b>
                   </Typography>
                   ({exploitation.usages.join(', ')})
                 </div>

--- a/src/components/prelevements/point-exploitations.js
+++ b/src/components/prelevements/point-exploitations.js
@@ -120,8 +120,9 @@ const PointExploitations = ({pointPrelevement}) => {
                   <Typography className='px-2'>
                     <b>
                       {exploitation.beneficiaire.nom
-                        || exploitation.beneficiaire.raison_sociale
-                        || exploitation.beneficiaire.sigle}
+                        ? `${exploitation.beneficiaire?.civilite || ''} ${exploitation.beneficiaire.nom} ${exploitation.beneficiaire?.prenom || ''}`
+                        : (exploitation.beneficiaire.raison_sociale
+                        || exploitation.beneficiaire.sigle)}
                     </b>
                   </Typography>
                   ({exploitation.usages.join(', ')})


### PR DESCRIPTION
Cette PR ajoute l'affichage de la civilité et du prénom du préleveur dans la liste des exploitations d'un point de prélèvement.

(Pas de captures pour éviter d'afficher les noms des préleveurs)