### PR TITLE
Améliorations du graphique "Documents associés aux exploitations"

### DIFF
--- a/src/components/prelevements/documents-chart.js
+++ b/src/components/prelevements/documents-chart.js
@@ -9,14 +9,14 @@ import LegendChart from '@/components/prelevements/legend-chart.js'
 
 function getColorForNature(index) {
   const colors = [
-    fr.colors.decisions.artwork.major.greenTilleulVerveine.hover,
     fr.colors.decisions.artwork.major.greenBourgeon.hover,
     fr.colors.decisions.artwork.major.greenEmeraude.hover,
     fr.colors.decisions.artwork.major.greenMenthe.hover,
     fr.colors.decisions.artwork.major.greenArchipel.hover,
     fr.colors.decisions.artwork.major.blueEcume.hover,
     fr.colors.decisions.artwork.major.blueCumulus.hover,
-    fr.colors.decisions.artwork.major.purpleGlycine.hover
+    fr.colors.decisions.artwork.major.purpleGlycine.hover,
+    fr.colors.decisions.artwork.major.pinkMacaron.hover
   ]
 
   return colors[index % colors.length]

--- a/src/components/prelevements/documents-chart.js
+++ b/src/components/prelevements/documents-chart.js
@@ -3,6 +3,7 @@
 import {useMemo} from 'react'
 
 import {fr} from '@codegouvfr/react-dsfr'
+import {Paper} from '@mui/material'
 import {BarChart} from '@mui/x-charts/BarChart'
 
 import LegendChart from '@/components/prelevements/legend-chart.js'
@@ -21,6 +22,38 @@ function getColorForNature(index) {
 
   return colors[index % colors.length]
 }
+
+const CustomTooltip = e => (
+  <Paper
+    elevation={2}
+    style={{
+      padding: '.5em 1em'
+    }}
+  >
+    <p className='p-2 border-b mb-2'>
+      {e.axisValue}
+    </p>
+    {e.series
+      .filter(s => s.data[e.dataIndex] !== 0)
+      .map(s => (
+        <div
+          key={s.label}
+          className='flex justify-between'
+        >
+          <span className='flex items-center'>
+            <div
+              className='w-2 h-2 rounded-full mr-3'
+              style={{
+                backgroundColor: s.color
+              }}
+            />
+            <span className='mr-10'>{s.label}</span>
+          </span>
+          <span>{s.data[e.dataIndex]}</span>
+        </div>
+      ))}
+  </Paper>
+)
 
 const DocumentChart = ({data}) => {
   const {xAxisData, series} = useMemo(() => {
@@ -70,6 +103,9 @@ const DocumentChart = ({data}) => {
           }
         ]}
         height={450}
+        slots={{
+          axisContent: CustomTooltip
+        }}
       />
       <LegendChart series={series} />
     </div>


### PR DESCRIPTION
Cette PR améliore l'affichage du graphique qui affiche les documents associés aux exploitations sur la page "/statistiques".

- Modifications des couleurs du graph
- Création d'un "tootlip" custom, permettant de masquer les valeurs à 0

## Captures : 

### Avant : 

![Enregistrement de l’écran 2025-03-24 à 14 37 41](https://github.com/user-attachments/assets/512aeb84-abee-4f25-99a0-c38e7e6db238)

### Après : 

![Enregistrement de l’écran 2025-03-24 à 14 38 28](https://github.com/user-attachments/assets/aa45d1b7-7b60-4d6d-ab08-66479fe10f42)
