### PR TITLE
Recherche partielle dans la liste des préleveurs

### DIFF
--- a/src/components/preleveurs/preleveurs-list.js
+++ b/src/components/preleveurs/preleveurs-list.js
@@ -10,12 +10,12 @@ import {
   InputAdornment,
   TextField
 } from '@mui/material'
-import {deburr} from 'lodash-es'
 import Link from 'next/link'
 
 import FlexSearch from '../../../node_modules/flexsearch/dist/flexsearch.bundle.module.min.js'
 
 import {getUsagesColors} from '@/components/map/legend-colors.js'
+import {normalizeString} from '@/utils/string.js'
 
 const PreleveursList = ({preleveurs}) => {
   const [filteredPreleveurs, setFilteredPreleveurs] = useState(preleveurs)
@@ -38,10 +38,10 @@ const PreleveursList = ({preleveurs}) => {
         preleveur.id_beneficiaire,
         {
           idBeneficiaire: preleveur.id_beneficiaire.toString(),
-          nom: deburr(preleveur.nom?.toLowerCase()),
-          prenom: deburr(preleveur.prenom?.toLowerCase()),
-          raison_sociale: deburr(preleveur.raison_sociale?.toLowerCase()), // eslint-disable-line camelcase
-          sigle: preleveur.sigle?.toLowerCase()
+          nom: normalizeString(preleveur.nom),
+          prenom: normalizeString(preleveur.prenom),
+          raison_sociale: normalizeString(preleveur.raison_sociale), // eslint-disable-line camelcase
+          sigle: normalizeString(preleveur.sigle)
         }
       )
     }
@@ -50,7 +50,7 @@ const PreleveursList = ({preleveurs}) => {
   }, [preleveurs])
 
   const handleFilter = e => {
-    const query = deburr(e.target.value.toLowerCase())
+    const query = normalizeString(e.target.value)
     const results = index.current.search(query, {
       suggest: true,
       limit: 10,

--- a/src/components/preleveurs/preleveurs-list.js
+++ b/src/components/preleveurs/preleveurs-list.js
@@ -26,7 +26,10 @@ const PreleveursList = ({preleveurs}) => {
         id: 'id_beneficiaire',
         index: ['nom', 'prenom', 'raison_sociale', 'sigle'],
         store: true
-      }
+      },
+      tokenize: 'forward',
+      suggest: true,
+      depth: 2
     })
 
     for (const preleveur of preleveurs) {
@@ -46,15 +49,22 @@ const PreleveursList = ({preleveurs}) => {
   }, [preleveurs])
 
   const handleFilter = e => {
-    const results = index.current.search(e.target.value.toLowerCase())
+    const query = e.target.value.toLowerCase()
+    const results = index.current.search(query, {
+      suggest: true,
+      limit: 10,
+      enrich: true
+    })
     const newPreleveurs = []
 
-    if (results.length > 0) {
+    if (query.length > 0 && results.length > 0) {
       for (const r of results) {
-        const {result} = r
-        for (const r of result) {
-          const newPreleveur = preleveurs.find(p => p.id_beneficiaire === r)
-          newPreleveurs.push(newPreleveur)
+        for (const doc of r.result) {
+          const newPreleveur = preleveurs.find(p => p.id_beneficiaire === doc.id)
+
+          if (newPreleveur && !newPreleveurs.some(p => p.id_beneficiaire === newPreleveur.id_beneficiaire)) {
+            newPreleveurs.push(newPreleveur)
+          }
         }
       }
 

--- a/src/components/preleveurs/preleveurs-list.js
+++ b/src/components/preleveurs/preleveurs-list.js
@@ -28,7 +28,7 @@ const PreleveursList = ({preleveurs}) => {
         index: ['nom', 'prenom', 'raison_sociale', 'sigle'],
         store: true
       },
-      tokenize: 'forward',
+      tokenize: 'full',
       suggest: true,
       depth: 2
     })
@@ -54,7 +54,9 @@ const PreleveursList = ({preleveurs}) => {
     const results = index.current.search(query, {
       suggest: true,
       limit: 10,
-      enrich: true
+      enrich: true,
+      bool: 'or',
+      threshold: 5
     })
 
     if (query.length === 0) {

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,0 +1,5 @@
+import {deburr} from 'lodash-es'
+
+export function normalizeString(string) {
+  return deburr(string?.toLowerCase())
+}

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,5 +1,9 @@
 import {deburr} from 'lodash-es'
 
 export function normalizeString(string) {
-  return deburr(string?.toLowerCase())
+  if (!string) {
+    return string
+  }
+
+  return deburr(string.toLowerCase())
 }


### PR DESCRIPTION
Cette PR modifie le fonctionnement de la recherche dans la liste des préleveurs.

Actuellement, il faut taper le nom ou sigle complet d'un préleveur pour obtenir un résultat.
Avec ces modifications, l'utilisateur pourra effectuer une recherche partielle sur le nom ou sigle d'un préleveur.

Exemple : "oue" retourne maintenant "Territoires de l'ouest"

Fix #45 