### PR TITLE
Bouton pour exporter la liste des points de prélèvement

### DIFF
--- a/src/app/prelevements/page.js
+++ b/src/app/prelevements/page.js
@@ -25,6 +25,7 @@ import PointSidePanel from '@/components/map/point-side-panel.js'
 import PointsListHeader from '@/components/map/points-list-header.js'
 import PointsList from '@/components/map/points-list.js'
 import useEvent from '@/hook/use-event.js'
+import {downloadCsv} from '@/lib/export-csv.js'
 import {extractTypeMilieu, extractUsages} from '@/lib/points-prelevement.js'
 
 const Page = () => {
@@ -121,6 +122,12 @@ const Page = () => {
     }
   }, [pointId, points])
 
+  const exportPointsList = () => {
+    const result = points.filter(p => filteredPoints.includes(p.id_point))
+
+    downloadCsv(result, 'points-prelevements-export.csv')
+  }
+
   return (
     <SidePanelLayout
       header={
@@ -135,6 +142,7 @@ const Page = () => {
             filters={filters}
             typeMilieuOptions={typeMilieuOptions}
             usagesOptions={usagesOptions}
+            exportList={exportPointsList}
             onFilter={handleFilter}
           />
         )

--- a/src/components/map/points-list-header.js
+++ b/src/components/map/points-list-header.js
@@ -1,8 +1,9 @@
+import {Button} from '@codegouvfr/react-dsfr/Button'
 import {Typography} from '@mui/material'
 
 import MapFilters from '@/components/map/map-filters.js'
 
-const PointsListHeader = ({filters, resultsCount, typeMilieuOptions, usagesOptions, onFilter}) => (
+const PointsListHeader = ({filters, resultsCount, typeMilieuOptions, usagesOptions, onFilter, exportList}) => (
   <div className='flex flex-col gap-2'>
     <Typography variant='h6'>Liste des points de prélèvement</Typography>
     {/* Barre de filtres */}
@@ -15,12 +16,18 @@ const PointsListHeader = ({filters, resultsCount, typeMilieuOptions, usagesOptio
         onFilter({name: '', typeMilieu: '', usages: []})}
     />
     {resultsCount !== null && (
-      <Typography variant='body2'>
+      <Typography variant='body2' component='div'>
         {resultsCount === 0 && 'Aucun point ne correspond à vos critères de recherche'}
         {resultsCount > 0 && (
-          <>
-            <strong>{resultsCount}</strong> point{resultsCount > 1 ? 's' : ''} de prélèvement
-          </>
+          <div className='flex justify-between items-center pt-2'>
+            <span><strong>{resultsCount}</strong> point{resultsCount > 1 ? 's' : ''} de prélèvement</span>
+            <Button
+              size='small'
+              iconId='fr-icon-download-line'
+              title='Télécharger la liste au format csv'
+              onClick={exportList}
+            />
+          </div>
         )}
       </Typography>
     )}

--- a/src/lib/export-csv.js
+++ b/src/lib/export-csv.js
@@ -1,0 +1,67 @@
+function jsonToCsv(jsonData) {
+  const csvRows = []
+
+  const headers = getHeaders(jsonData)
+  csvRows.push(headers.join(','))
+
+  for (const row of jsonData) {
+    const values = headers.map(header => {
+      const value = getValueByPath(row, header)
+      const escaped = (value !== null && value !== undefined) ? value.toString().replaceAll('"', '""') : ''
+      return `"${escaped}"`
+    })
+    csvRows.push(values.join(','))
+  }
+
+  return csvRows.join('\n')
+}
+
+function getHeaders(jsonData) {
+  const headers = new Set()
+  for (const item of jsonData) {
+    extractHeaders(item, '', headers)
+  }
+
+  return [...headers]
+}
+
+function extractHeaders(item, prefix, headers) {
+  for (const key in item) {
+    if (Object.hasOwn(item, (key))) {
+      const fullKey = prefix ? `${prefix}.${key}` : key
+      if (typeof item[key] === 'object' && item[key] !== null) {
+        extractHeaders(item[key], fullKey, headers)
+      } else {
+        headers.add(fullKey)
+      }
+    }
+  }
+}
+
+function getValueByPath(obj, path) {
+  const parts = path.split('.')
+  let current = obj
+  for (const part of parts) {
+    if (current && current[part] !== 'undefined') {
+      current = current[part]
+    } else {
+      return undefined
+    }
+  }
+
+  return current
+}
+
+export function downloadCsv(data, filename) {
+  const csvContent = jsonToCsv(data)
+  const blob = new Blob([csvContent], {type: 'text/csv;charset=utf-8;'})
+  const url = URL.createObjectURL(blob)
+
+  const link = document.createElement('a')
+  link.setAttribute('href', url)
+  link.setAttribute('download', filename)
+  link.style.visibility = 'hidden'
+  document.body.append(link)
+  link.click()
+  link.remove()
+}


### PR DESCRIPTION
Cette PR ajoute un bouton permettant d'exporter la liste des points de prélèvement, filtrée ou non, en CSV.

L'utilisateur peut par exemple sélectionner tous les points de prélèvement qui ont pour usage "eau potable" et exporter la liste dans un fichier `.csv`.

