### PR TITLE
Corrige le filtre sur la colonne "Déclarants" du tableau "Dossiers déposés"

### DIFF
--- a/src/components/declarations/dossiers-list.js
+++ b/src/components/declarations/dossiers-list.js
@@ -13,6 +13,7 @@ import DossierModal from '@/components/declarations/dossier-modal.js'
 import DossierStateBadge from '@/components/declarations/dossier-state-badge.js'
 import PrelevementTypeBadge from '@/components/declarations/prelevement-type-badge.js'
 import TypeSaisieBadge from '@/components/declarations/type-saisie-badge.js'
+import {normalizeName} from '@/utils/string.js'
 
 const modal = createModal({
   id: 'invalid-dossiers-modal',
@@ -32,10 +33,6 @@ const convertDossierToRow = dossier => ({
   numeroArreteAot: dossier.numeroArreteAot,
   typeDonnees: dossier.typeDonnees
 })
-
-function getDeclarantName(declarant) {
-  return declarant.raisonSociale || declarant.nom
-}
 
 function renderErrorsCount({field, row}) {
   const value = row[field]
@@ -81,8 +78,13 @@ const DossiersList = ({dossiers}) => {
             field: 'declarant',
             headerName: 'Déclarant',
             width: 300,
-            sortComparator: (a, b) => getDeclarantName(a).localeCompare(getDeclarantName(b)),
-            valueFormatter: ({raisonSociale, nom, prenom}) => raisonSociale || `${nom.toUpperCase()} ${prenom}`
+            renderCell({row}) {
+              return (
+                row.declarant?.raisonSociale
+                  || `${normalizeName(row.declarant.nom)} ${normalizeName(row.declarant.prenom)}`
+              )
+            },
+            valueGetter: params => params && params.raisonSociale ? params.raisonSociale : `${params.nom} ${params.prenom}`
           },
           {
             field: 'typePrelevement',

--- a/src/components/declarations/dossiers-list.js
+++ b/src/components/declarations/dossiers-list.js
@@ -8,6 +8,7 @@ import {Tooltip} from '@mui/material'
 import {DataGrid, GridToolbar} from '@mui/x-data-grid'
 import {frFR} from '@mui/x-data-grid/locales'
 import {format} from 'date-fns'
+import {deburr} from 'lodash-es'
 
 import DossierModal from '@/components/declarations/dossier-modal.js'
 import DossierStateBadge from '@/components/declarations/dossier-state-badge.js'
@@ -84,7 +85,9 @@ const DossiersList = ({dossiers}) => {
                   || `${normalizeName(row.declarant.nom)} ${normalizeName(row.declarant.prenom)}`
               )
             },
-            valueGetter: params => params && params.raisonSociale ? params.raisonSociale : `${params.nom} ${params.prenom}`
+            valueGetter: params => params && params.raisonSociale
+              ? deburr(params.raisonSociale)
+              : `${deburr(params.nom)} ${deburr(params.prenom)}`
           },
           {
             field: 'typePrelevement',

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -7,3 +7,13 @@ export function normalizeString(string) {
 
   return deburr(string.toLowerCase())
 }
+
+export function normalizeName(string) {
+  if (!string) {
+    return string
+  }
+
+  return string.split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}


### PR DESCRIPTION
L'option de filtre / recherche sur la colonne "Déclarants" du tableau "Dossiers déposés" ne retournait aucun résultat.

Ces modifications corrigent ce problème, le filtre fonctionne maintenant correctement sur la raison sociale, le prénom ou le nom d'un déclarant.

- Ajout d'une fonction pour normaliser les noms/prénoms des déclarants
- Ajout de `valueGetter` et `renderCell`
- Suppression du code inutile
