### PR TITLE
Correction de l'affichage du nombre de dépassement

### DIFF
--- a/src/components/prelevements/volumes-chart.js
+++ b/src/components/prelevements/volumes-chart.js
@@ -57,7 +57,9 @@ const VolumesChart = ({idExploitation}) => {
 
   const hasVolumeMax = volumes.volumeJournalierMax
   const nbValeursRenseignees = showAll ? volumes.nbValeursRenseignees : displayData.length
-  const nbDepassements = showAll ? volumes.nbDepassements : displayData.filter(v => v.depassement).length
+  const nbDepassements = showAll
+    ? (volumes.nbDepassements ?? '0')
+    : (displayData.some(v => v.depassement).length > 0 ? displayData.filter(v => v.depassement).length : '0')
 
   useEffect(() => {
     async function getVolumes() {


### PR DESCRIPTION
Dans l'affichage des volumes d'une exploitation dans la partie `prelevements/{id}/exploitations`, 
lorsqu'il n'y avait pas de dépassement, le message n'indiquait pas le '0'.

J'ai modifié la condition afin de corriger le problème.