### PR TITLE
Correction de l'affichage du tooltip

### DIFF
--- a/src/components/prelevements/volumes-chart.js
+++ b/src/components/prelevements/volumes-chart.js
@@ -41,7 +41,7 @@ const VolumesChart = ({idExploitation}) => {
       area: false,
       curve: 'linear',
       valueFormatter(value) {
-        return value ? `${Number.parseFloat(value).toLocaleString('fr-FR')} m³` : 'Non renseigné'
+        return value ? `${Number.parseFloat(value).toLocaleString('fr-FR')} m³` : null
       }
     },
     {
@@ -104,7 +104,7 @@ const VolumesChart = ({idExploitation}) => {
             xAxis={[
               {
                 data: xLabels,
-                scaleType: 'band',
+                scaleType: 'point',
                 valueFormatter: date => format(parseISO(date), 'dd/MM/yyyy', {locale: fr}),
                 tickLabelStyle: {
                   angle: 45,


### PR DESCRIPTION
En rapport avec #81 : 

Il semble que l'infobulle affiche les données de la légende du graphique, ça ne se produit que lorsqu'il y a beaucoup de points sur le graphique.
J'ai réussi à reproduire le problème uniquement sur le point 84.

J'ai modifié quelques propriétés du graphique mais le problème persiste sur ce point.
