### PR TITLE
Corrige l'affichage de "autres_noms"

### DIFF
--- a/src/components/map/point-side-panel.js
+++ b/src/components/map/point-side-panel.js
@@ -19,7 +19,6 @@ import Link from 'next/link.js'
 import ExploitationAccordion from '../exploitation-accordion.js'
 
 import {getExploitationsByPointId} from '@/app/api/points-prelevement.js'
-import {formatAutresNoms} from '@/lib/points-prelevement.js'
 
 const SectionTitle = ({title}) => (
   <Box className='my-4'>
@@ -58,9 +57,9 @@ const PointSidePanel = ({point}) => {
 
   return (
     <Box className='flex flex-col gap-4 px-4 pb-4'>
-      {point.autres_noms && (
+      {point.autresNoms && (
         <Typography variant='caption'>
-          {formatAutresNoms(point.autres_noms)}
+          {point.autresNoms}
         </Typography>
       )}
 

--- a/src/components/map/popup.js
+++ b/src/components/map/popup.js
@@ -7,11 +7,10 @@ import {
 } from '@mui/material'
 
 import formatDate from '@/lib/format-date.js'
-import {formatAutresNoms} from '@/lib/points-prelevement.js'
 
 const Popup = ({point}) => {
   const theme = useTheme()
-  const {nom, autres_noms: autresNoms, preleveurs, exploitationsStatus, exploitationsStartDate, usages, type_milieu: typeMilieu, zre, reservoir_biologique: reservoirBiologique} = point
+  const {nom, autresNoms, preleveurs, exploitationsStatus, exploitationsStartDate, usages, type_milieu: typeMilieu, zre, reservoir_biologique: reservoirBiologique} = point
 
   return (
     // TODO : Utiliser le theme DSFR
@@ -21,7 +20,7 @@ const Popup = ({point}) => {
       </Typography>
 
       <Typography variant='caption'>
-        {autresNoms && formatAutresNoms(autresNoms)}
+        {autresNoms}
       </Typography>
 
       <Box>

--- a/src/components/prelevements/point-identification.js
+++ b/src/components/prelevements/point-identification.js
@@ -3,10 +3,8 @@ import Launch from '@mui/icons-material/Launch'
 import {Box, Typography} from '@mui/material'
 import Link from 'next/link'
 
-import {formatAutresNoms} from '@/lib/points-prelevement.js'
-
 const PointIdentification = ({pointPrelevement, lienBss, lienBnpe}) => {
-  const {id_point: idPoint, nom, autres_noms: autresNoms} = pointPrelevement
+  const {id_point: idPoint, nom, autresNoms} = pointPrelevement
 
   return (
     <Box sx={{m: 2, p: 3}}>
@@ -17,7 +15,7 @@ const PointIdentification = ({pointPrelevement, lienBss, lienBnpe}) => {
         {idPoint} - {nom}
       </Typography>
       {autresNoms && (
-        <div><i>{formatAutresNoms(autresNoms)}</i></div>
+        <div><i>{autresNoms}</i></div>
       )}
       {lienBss && (
         <Box sx={{mt: 2}}>

--- a/src/lib/points-prelevement.js
+++ b/src/lib/points-prelevement.js
@@ -1,14 +1,3 @@
-export function formatAutresNoms(autresNoms) {
-  if (!autresNoms) {
-    return null
-  }
-
-  const cleanedStr = autresNoms.replaceAll(/[{}"]/g, '')
-  const result = '(' + [...new Set(cleanedStr.split(','))].join(', ') + ')'
-
-  return result
-}
-
 export function extractUsages(points) {
   const usagesSet = new Set()
   for (const point of points) {


### PR DESCRIPTION
Le champ `autres_noms` a été remplacé dans la partie backend par un champ `autresNoms`.
Ce champ est maintenant formaté correctement lorsqu'il arrive côté client, ce qui permet de supprimer la fonction `formatAutresNoms`.

>[!warning]
>Ces modifications nécessitent [les corrections côté serveur](https://github.com/MTES-MCT/prelevement-deau-back/pull/23)