### PR TITLE
Édition d'un point de prélèvement

### DIFF
--- a/src/app/api/points-prelevement.js
+++ b/src/app/api/points-prelevement.js
@@ -28,6 +28,16 @@ export async function createPointPrelevement(payload) {
   return response.json()
 }
 
+export async function editPointPrelevement(id, payload) {
+  const response = await fetch(`${API_URL}/api/points-prelevement/${id}`, {
+    headers,
+    method: 'PUT',
+    body: JSON.stringify(payload)
+  })
+
+  return response.json()
+}
+
 export async function getPreleveur(id) {
   try {
     const response = await fetch(`${API_URL}/api/preleveurs/${id}`, {headers})

--- a/src/app/prelevements/[id]/edit/page.js
+++ b/src/app/prelevements/[id]/edit/page.js
@@ -1,0 +1,26 @@
+import {
+  getBnpe,
+  getMeContinentales,
+  getMeso,
+  getPointPrelevement
+} from '@/app/api/points-prelevement.js'
+import PointEditionForm from '@/components/form/point-edition-form.js'
+
+const Page = async ({params}) => {
+  const {id} = await params
+  const pointPrelevement = await getPointPrelevement(id)
+  const bnpeList = await getBnpe()
+  const mesoList = await getMeso()
+  const meContinentalesBvList = await getMeContinentales()
+
+  return (
+    <PointEditionForm
+      pointPrelevement={pointPrelevement}
+      bnpeList={bnpeList}
+      mesoList={mesoList}
+      meContinentalesBvList={meContinentalesBvList}
+    />
+  )
+}
+
+export default Page

--- a/src/app/prelevements/[id]/layout.js
+++ b/src/app/prelevements/[id]/layout.js
@@ -9,7 +9,7 @@ const Layout = ({children}) => {
 
   return (
     <>
-      <div className='pt-5 pl-5'>
+      <div className='p-5'>
         <ArrowBackIcon className='pr-1' />
         <Link href={`/prelevements?point-prelevement=${id}`}>Retour</Link>
       </div>

--- a/src/app/prelevements/new/page.js
+++ b/src/app/prelevements/new/page.js
@@ -11,7 +11,7 @@ const Page = async () => {
 
   return (
     <div>
-      <div className='pt-5 pl-5'>
+      <div className='p-5'>
         <ArrowBackIcon className='pr-1' />
         <Link href='/prelevements'>Retour</Link>
       </div>

--- a/src/components/form/mini-map-form.js
+++ b/src/components/form/mini-map-form.js
@@ -8,7 +8,7 @@ import maplibre from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import vectorIGN from '@/components/map/styles/vector-ign.json'
 
-const MiniMapForm = ({setGeom}) => {
+const MiniMapForm = ({geom, setGeom}) => {
   const mapContainerRef = useRef(null)
   const mapRef = useRef(null)
   const geojson = useRef({
@@ -16,10 +16,11 @@ const MiniMapForm = ({setGeom}) => {
     features: [
       {
         type: 'Feature',
-        geometry: {
-          type: 'Point',
-          coordinates: [55.55, -21.13]
-        }
+        geometry: geom
+          ? {...geom} : {
+            type: 'Point',
+            coordinates: [55.55, -21.13]
+          }
       }
     ]
   })

--- a/src/components/form/optional-point-fields-form.js
+++ b/src/components/form/optional-point-fields-form.js
@@ -29,26 +29,29 @@ const OptionalPointFieldsForm = (
     <Input
       label='Autres noms'
       nativeInputProps={{
+        defaultValue: point?.autresNoms,
         placeholder: 'Entrer les autres noms',
-        onChange: e => setPoint({...point, autresNoms: e.target.value})
+        onChange: e => setPoint(prev => ({...prev, autresNoms: e.target.value}))
       }}
     />
     <Input
       label='Code AIOT'
       nativeInputProps={{
+        defaultValue: point?.code_aiot,
         placeholder: 'Entrer le code AIOT',
-        onChange: e => setPoint({...point, code_aiot: e.target.value})
+        onChange: e => setPoint(prev => ({...prev, code_aiot: e.target.value}))
       }}
     />
     <Select
       label='Code mésorégion hydrographique'
       placeholder='Sélectionner le code MESO'
       nativeSelectProps={{
-        onChange: e => setPoint(
-          {
-            ...point,
+        defaultValue: point?.meso?.nom,
+        onChange: e => setPoint(prev =>
+          ({
+            ...prev,
             meso: mesoList.find(() => e.target.value).code
-          }
+          })
         )
       }}
       options={mesoList.map(meso => ({
@@ -63,8 +66,9 @@ const OptionalPointFieldsForm = (
       <Input
         label='Cours d’eau'
         nativeInputProps={{
+          defaultValue: point?.cours_eau,
           placeholder: 'Entrer le nom du cours d’eau',
-          onChange: e => setPoint({...point, cours_eau: e.target.value})
+          onChange: e => setPoint(prev => ({...prev, cours_eau: e.target.value}))
         }}
       />
       <Input
@@ -72,8 +76,9 @@ const OptionalPointFieldsForm = (
         type='number'
         nativeInputProps={{
           type: 'number',
+          defaultValue: point?.profondeur,
           placeholder: 'Entrer la profondeur',
-          onChange: e => setPoint({...point, profondeur: Number(e.target.value)})
+          onChange: e => setPoint(prev => ({...prev, profondeur: Number(e.target.value)}))
         }}
       />
     </div>
@@ -87,14 +92,15 @@ const OptionalPointFieldsForm = (
               bnpe,
               label: bnpe.code_point_prelevement
             }))}
+            defaultValue={point?.bnpe?.point}
             className={className}
             id={id}
             placeholder={placeholder}
             type={type}
-            onChange={(e, value) => setPoint({
-              ...point,
-              bnpe: value?.bnpe?.code_point_prelevement || null
-            })}
+            onChange={(e, value) => setPoint(prev => ({
+              ...prev,
+              bnpe: value?.bnpe?.code_point_prelevement
+            }))}
           />
         )}
       />
@@ -109,14 +115,15 @@ const OptionalPointFieldsForm = (
               meContinentales,
               label: meContinentales.code_dce
             }))}
+            defaultValue={point?.meContinentalesBv?.code}
             className={className}
             id={id}
             placeholder={placeholder}
             type={type}
-            onChange={(e, value) => setPoint({
-              ...point,
-              meContinentalesBv: value?.meContinentales?.code_dce || null
-            })}
+            onChange={(e, value) => setPoint(prev => ({
+              ...prev,
+              meContinentalesBv: value?.meContinentales?.code_dce
+            }))}
           />
         )}
       />
@@ -124,28 +131,33 @@ const OptionalPointFieldsForm = (
     <Input
       label='Bassin versant BD Carthage'
       nativeInputProps={{
+        defaultValue: point?.bvBdCarthage,
         placeholder: 'Entrer le bassin versant BD Carthage',
-        onChange: e => setPoint({...point, bvBdCarthage: e.target.value})
+        onChange: e => setPoint(prev => ({...prev, bvBdCarthage: e.target.value}))
       }}
     />
     <div className='w-full grid grid-cols-2 gap-4 py-5'>
       <DynamicCheckbox
         options={[
           {
-            label: 'Zone reglementée (ZRE)'
+            label: 'Zone reglementée (ZRE)',
+            nativeInputProps: {
+              defaultChecked: point.zre || false,
+              onChange: e => setPoint(prev => ({...prev, zre: e.target.checked}))
+            }
           }
         ]}
-        checked={point.zre}
-        onChange={e => setPoint({...point, zre: e.target.checked})}
       />
       <DynamicCheckbox
         options={[
           {
-            label: 'Réservoir biologique'
+            label: 'Réservoir biologique',
+            nativeInputProps: {
+              defaultChecked: point.reservoir_biologique || false,
+              onChange: e => setPoint(prev => ({...prev, reservoir_biologique: e.target.checked}))
+            }
           }
         ]}
-        checked={point.reservoir_biologique}
-        onChange={e => setPoint({...point, reservoir_biologique: e.target.checked})}
       />
     </div>
     <Typography variant='h5' sx={{pb: 5}}>
@@ -153,10 +165,12 @@ const OptionalPointFieldsForm = (
     </Typography>
     <Input
       textArea
-      label='Remarques'
-      nativeInputProps={{
-        onChange: e => setPoint({...point, remarques: e.target.value})
+      label='Remarque'
+      nativeTextAreaProps={{
+        placeholder: 'Entrer une remarque',
+        defaultValue: point?.remarque
       }}
+      onChange={e => setPoint(prev => ({...prev, remarque: e.target.value}))}
     />
   </div>
 )

--- a/src/components/form/point-creation-form.js
+++ b/src/components/form/point-creation-form.js
@@ -4,22 +4,13 @@
 import {useEffect, useState} from 'react'
 
 import Button from '@codegouvfr/react-dsfr/Button'
-import Input from '@codegouvfr/react-dsfr/Input'
-import Select from '@codegouvfr/react-dsfr/SelectNext'
-import {ChevronRight} from '@mui/icons-material'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import {
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Typography
-} from '@mui/material'
+import {Typography} from '@mui/material'
 import {useRouter} from 'next/navigation'
 
 import {createPointPrelevement} from '@/app/api/points-prelevement.js'
-import MiniMapForm from '@/components/form/mini-map-form.js'
-import OptionalPointFieldsForm from '@/components/form/optional-point-fields-form.js'
+import PointForm from '@/components/form/point-form.js'
 import {getCommuneFromCoords} from '@/lib/communes.js'
+import {emptyStringToNull} from '@/utils/string.js'
 
 const PointCreationForm = ({bnpeList, mesoList, meContinentalesBvList}) => {
   const router = useRouter()
@@ -28,34 +19,17 @@ const PointCreationForm = ({bnpeList, mesoList, meContinentalesBvList}) => {
     type_milieu: '',
     precision_geom: ''
   })
-  const typesDeMilieu = ['Eau de surface', 'Eau souterraine', 'Eau de transition']
-  const [isExpanded, setIsExpanded] = useState(false)
   const [isDisabled, setIsDisabled] = useState(true)
   const [validationErrors, setValidationErrors] = useState([])
   const [error, setError] = useState(null)
-  const precisionsGeom = [
-    'Repérage carte',
-    'Coordonnées précises',
-    'Coordonnées précises (ARS)',
-    'Coordonnées du centroïde de la commune',
-    'Coordonnées précises (rapport HGA)',
-    'Coordonnées précises (ARS 2013)',
-    'Coordonnées précises (AP)',
-    'Coordonnées précises (BSS)',
-    'Coordonnées précises (BNPE – accès restreint)',
-    'Précision inconnue',
-    'Coordonnées estimées (précision du kilomètre)',
-    'Coordonnées précises (BNPE)',
-    'Coordonnées précises (DEAL)',
-    'Coordonnées précises (DLE)'
-  ]
 
   const handleSubmit = async () => {
     setError(null)
     setValidationErrors([])
 
     try {
-      const response = await createPointPrelevement(point)
+      const cleanedPoint = emptyStringToNull(point)
+      const response = await createPointPrelevement(cleanedPoint)
 
       if (response.code === 400) {
         if (response.validationErrors) {
@@ -100,74 +74,14 @@ const PointCreationForm = ({bnpeList, mesoList, meContinentalesBvList}) => {
       <Typography variant='h3' sx={{pb: 5}}>
         Création d&apos;un point de prélèvement
       </Typography>
-      <Input
-        required
-        label='Nom du point de prélèvement *'
-        nativeInputProps={{
-          placeholder: 'Entrer le nom du point de prélèvement',
-          value: point.nom,
-          onChange: e => setPoint({...point, nom: e.target.value})
-        }}
+      <PointForm
+        point={point}
+        setPoint={setPoint}
+        handleSetGeom={handleSetGeom}
+        bnpeList={bnpeList}
+        meContinentalesBvList={meContinentalesBvList}
+        mesoList={mesoList}
       />
-      <Select
-        label='Type de milieu *'
-        placeholder='Sélectionner le type de milieu'
-        nativeSelectProps={{
-          value: point.type_milieu,
-          onChange: e => setPoint({...point, type_milieu: e.target.value})
-        }}
-        options={typesDeMilieu.map(type => ({
-          value: type,
-          label: type
-        }))}
-      />
-      <div className='pb-5'>
-        <Typography variant='h5'>
-          Localisation
-        </Typography>
-        <p>Sélectionner l&apos;emplacement du point sur la carte <small><i>(Cliquer ou déplacer le point)</i></small></p>
-      </div>
-      <div style={{height: '600px', marginBottom: '2rem'}}>
-        <MiniMapForm setGeom={handleSetGeom} />
-      </div>
-      <Select
-        label='Précision géométrique'
-        placeholder='Sélectionner une précision géométrique'
-        nativeSelectProps={{
-          value: point.precision_geom,
-          onChange: e => setPoint({...point, precision_geom: e.target.value})
-        }}
-        options={precisionsGeom.map(precision => ({
-          value: precision,
-          label: precision
-        }))}
-      />
-      <div className='py-5'>
-        <Accordion
-          expanded={isExpanded}
-          elevation={0}
-          sx={{
-            border: '1px solid lightgrey'
-          }}
-          onChange={() => setIsExpanded(!isExpanded)}
-        >
-          <AccordionSummary>
-            <Typography className='text-center w-full'>
-              {isExpanded ? 'Masquer les champs optionnels' : 'Afficher les champs optionnels'}
-              {isExpanded ? <ExpandMoreIcon /> : <ChevronRight />}
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <OptionalPointFieldsForm
-              point={point}
-              setPoint={setPoint}
-              bnpeList={bnpeList}
-              mesoList={mesoList}
-              meContinentalesBvList={meContinentalesBvList}
-            />
-          </AccordionDetails>
-        </Accordion>
-      </div>
       {error && (
         <div className='text-center p-5 text-red-500'>
           <p><b>Un problème est survenu :</b></p>

--- a/src/components/form/point-edition-form.js
+++ b/src/components/form/point-edition-form.js
@@ -1,0 +1,100 @@
+'use client'
+
+import {useState} from 'react'
+
+import Button from '@codegouvfr/react-dsfr/Button'
+import {Typography} from '@mui/material'
+import {useRouter} from 'next/navigation'
+
+import {editPointPrelevement} from '@/app/api/points-prelevement.js'
+import PointForm from '@/components/form/point-form.js'
+import {getCommuneFromCoords} from '@/lib/communes.js'
+import {emptyStringToNull} from '@/utils/string.js'
+
+const PointEditionForm = ({pointPrelevement, bnpeList, mesoList, meContinentalesBvList}) => {
+  const router = useRouter()
+  const [payload, setPayload] = useState({})
+  const point = {...pointPrelevement}
+  const [validationErrors, setValidationErrors] = useState([])
+  const [error, setError] = useState(null)
+
+  const handleSubmit = async () => {
+    setError(null)
+    setValidationErrors([])
+
+    try {
+      const cleanedPayload = emptyStringToNull(payload)
+      const response = await editPointPrelevement(point.id_point, cleanedPayload)
+
+      if (response.code === 400) {
+        if (response.validationErrors) {
+          setValidationErrors(response.validationErrors)
+        } else {
+          setError(response.message)
+        }
+      } else {
+        router.push(`/prelevements?point-prelevement=${response.id_point}`)
+      }
+    } catch (error) {
+      setError(error.message)
+    }
+  }
+
+  const handleSetGeom = async geom => {
+    try {
+      const commune = await getCommuneFromCoords(
+        {
+          lon: geom.coordinates[0],
+          lat: geom.coordinates[1]
+        }
+      )
+
+      if (!commune) {
+        setError('Cette commune est introuvable.')
+        return
+      }
+
+      setPayload(prev => ({...prev, commune: commune.code, geom}))
+    } catch (error) {
+      setError(error.message)
+    }
+  }
+
+  return (
+    <div className='fr-container'>
+      <Typography variant='h3' sx={{pb: 5}}>
+        Création d&apos;un point de prélèvement
+      </Typography>
+      <PointForm
+        point={point}
+        setPoint={setPayload}
+        handleSetGeom={handleSetGeom}
+        bnpeList={bnpeList}
+        meContinentalesBvList={meContinentalesBvList}
+        mesoList={mesoList}
+      />
+      {error && (
+        <div className='text-center p-5 text-red-500'>
+          <p><b>Un problème est survenu :</b></p>
+          {error}
+        </div>
+      )}
+      {validationErrors?.length > 0 && (
+        <div className='text-center p-5 text-red-500'>
+          <p><b>{validationErrors.length === 1 ? 'Problème de validation :' : 'Problèmes de validation :'}</b></p>
+          {validationErrors.map(err => (
+            <p key={err.message}>{err.message}</p>
+          )
+          )}
+        </div>
+      )}
+      <div className='w-full flex justify-center p-5 mb-8'>
+        <Button onClick={handleSubmit}>
+          Valider les modifications sur le point de prélèvement {point.nom}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default PointEditionForm

--- a/src/components/form/point-edition-form.js
+++ b/src/components/form/point-edition-form.js
@@ -63,7 +63,7 @@ const PointEditionForm = ({pointPrelevement, bnpeList, mesoList, meContinentales
   return (
     <div className='fr-container'>
       <Typography variant='h3' sx={{pb: 5}}>
-        Création d&apos;un point de prélèvement
+        Édition du point de prélèvement {point.nom}
       </Typography>
       <PointForm
         point={point}

--- a/src/components/form/point-form.js
+++ b/src/components/form/point-form.js
@@ -50,16 +50,16 @@ const PointForm = ({
         label='Nom du point de prélèvement *'
         nativeInputProps={{
           placeholder: 'Entrer le nom du point de prélèvement',
-          value: point.nom,
-          onChange: e => setPoint({...point, nom: e.target.value})
+          defaultValue: point.nom,
+          onChange: e => setPoint(prev => ({...prev, nom: e.target.value}))
         }}
       />
       <Select
         label='Type de milieu *'
         placeholder='Sélectionner le type de milieu'
         nativeSelectProps={{
-          value: point.type_milieu,
-          onChange: e => setPoint({...point, type_milieu: e.target.value})
+          defaultValue: point.type_milieu,
+          onChange: e => setPoint(prev => ({...prev, type_milieu: e.target.value}))
         }}
         options={typesDeMilieu.map(type => ({
           value: type,
@@ -79,8 +79,8 @@ const PointForm = ({
         label='Précision géométrique'
         placeholder='Sélectionner une précision géométrique'
         nativeSelectProps={{
-          value: point.precision_geom,
-          onChange: e => setPoint({...point, precision_geom: e.target.value})
+          defaultValue: point.precision_geom,
+          onChange: e => setPoint(prev => ({...prev, precision_geom: e.target.value}))
         }}
         options={precisionsGeom.map(precision => ({
           value: precision,

--- a/src/components/form/point-form.js
+++ b/src/components/form/point-form.js
@@ -1,0 +1,120 @@
+/* eslint-disable camelcase */
+
+import {useState} from 'react'
+
+import Input from '@codegouvfr/react-dsfr/Input'
+import Select from '@codegouvfr/react-dsfr/SelectNext'
+import ChevronRight from '@mui/icons-material/ChevronRight'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography
+} from '@mui/material'
+
+import MiniMapForm from '@/components/form/mini-map-form.js'
+import OptionalPointFieldsForm from '@/components/form/optional-point-fields-form.js'
+
+const PointForm = ({
+  point,
+  setPoint,
+  handleSetGeom,
+  bnpeList,
+  meContinentalesBvList,
+  mesoList
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const typesDeMilieu = ['Eau de surface', 'Eau souterraine', 'Eau de transition']
+  const precisionsGeom = [
+    'Repérage carte',
+    'Coordonnées précises',
+    'Coordonnées précises (ARS)',
+    'Coordonnées du centroïde de la commune',
+    'Coordonnées précises (rapport HGA)',
+    'Coordonnées précises (ARS 2013)',
+    'Coordonnées précises (AP)',
+    'Coordonnées précises (BSS)',
+    'Coordonnées précises (BNPE – accès restreint)',
+    'Précision inconnue',
+    'Coordonnées estimées (précision du kilomètre)',
+    'Coordonnées précises (BNPE)',
+    'Coordonnées précises (DEAL)',
+    'Coordonnées précises (DLE)'
+  ]
+
+  return (
+    <>
+      <Input
+        required
+        label='Nom du point de prélèvement *'
+        nativeInputProps={{
+          placeholder: 'Entrer le nom du point de prélèvement',
+          value: point.nom,
+          onChange: e => setPoint({...point, nom: e.target.value})
+        }}
+      />
+      <Select
+        label='Type de milieu *'
+        placeholder='Sélectionner le type de milieu'
+        nativeSelectProps={{
+          value: point.type_milieu,
+          onChange: e => setPoint({...point, type_milieu: e.target.value})
+        }}
+        options={typesDeMilieu.map(type => ({
+          value: type,
+          label: type
+        }))}
+      />
+      <div className='pb-5'>
+        <Typography variant='h5'>
+          Localisation
+        </Typography>
+        <p>Sélectionner l&apos;emplacement du point sur la carte <small><i>(Cliquer ou déplacer le point)</i></small></p>
+      </div>
+      <div style={{height: '600px', marginBottom: '2rem'}}>
+        <MiniMapForm geom={point.geom} setGeom={handleSetGeom} />
+      </div>
+      <Select
+        label='Précision géométrique'
+        placeholder='Sélectionner une précision géométrique'
+        nativeSelectProps={{
+          value: point.precision_geom,
+          onChange: e => setPoint({...point, precision_geom: e.target.value})
+        }}
+        options={precisionsGeom.map(precision => ({
+          value: precision,
+          label: precision
+        }))}
+      />
+      <div className='py-5'>
+        <Accordion
+          expanded={isExpanded}
+          elevation={0}
+          sx={{
+            border: '1px solid lightgrey'
+          }}
+          onChange={() => setIsExpanded(!isExpanded)}
+        >
+          <AccordionSummary>
+            <Typography className='text-center w-full'>
+              {isExpanded ? 'Masquer les champs optionnels' : 'Afficher les champs optionnels'}
+              {isExpanded ? <ExpandMoreIcon /> : <ChevronRight />}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <OptionalPointFieldsForm
+              point={point}
+              setPoint={setPoint}
+              bnpeList={bnpeList}
+              mesoList={mesoList}
+              meContinentalesBvList={meContinentalesBvList}
+            />
+          </AccordionDetails>
+        </Accordion>
+      </div>
+    </>
+  )
+}
+
+export default PointForm

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -17,3 +17,12 @@ export function normalizeName(string) {
     .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ')
 }
+
+export function emptyStringToNull(obj) {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) =>
+      [key, (value === '' || value === undefined) ? null : value]
+    )
+  )
+}
+


### PR DESCRIPTION
Cette PR ajoute l'édition des points de prélèvement.

- Modification des composants de création pour les réutiliser pour l'édition
- Ajout de l'appel à l'API `editPointPrelevement`
- Ajout d'une fonction pour transformer les champs vides `''` en `null`
- Corrections visuelles

## Capture : 

![image](https://github.com/user-attachments/assets/61f78d7b-3f17-43c7-aca1-b6e7167a17e6)
