### PR TITLE
Use search params for dossiers list

### DIFF
--- a/src/components/declarations/dossiers-list.js
+++ b/src/components/declarations/dossiers-list.js
@@ -12,6 +12,7 @@ import {useRouter} from 'next/navigation'
 import DossierStateBadge from '@/components/declarations/dossier-state-badge.js'
 import PrelevementTypeBadge from '@/components/declarations/prelevement-type-badge.js'
 import TypeSaisieBadge from '@/components/declarations/type-saisie-badge.js'
+import {useGridSearchParams} from '@/hook/use-grid-search-params.js'
 import {getDossierURL} from '@/lib/urls.js'
 import {normalizeName} from '@/utils/string.js'
 
@@ -35,6 +36,8 @@ function renderDateCell(value) {
 const DossiersList = ({dossiers}) => {
   const router = useRouter()
   const [mounted, setMounted] = useState(false)
+
+  const {initialFilterModel, initialSortModel, onFilterModelChange, onSortModelChange} = useGridSearchParams()
 
   useEffect(() => {
     setMounted(true)
@@ -143,16 +146,18 @@ const DossiersList = ({dossiers}) => {
         ]}
         initialState={{
           pagination: {
-            paginationModel: {
-              pageSize: 20,
-              page: 0
-            }
+            paginationModel: {pageSize: 20, page: 0}
           },
           sorting: {
-            sortModel: [{field: 'dateDepot', sort: 'desc'}]
+            sortModel: initialSortModel
+          },
+          filter: {
+            filterModel: initialFilterModel
           }
         }}
         pageSizeOptions={[20, 50, 100]}
+        onFilterModelChange={onFilterModelChange}
+        onSortModelChange={onSortModelChange}
         onRowClick={params => router.push(getDossierURL({_id: params.row.id}))}
       />
     </div>

--- a/src/hook/use-grid-search-params.js
+++ b/src/hook/use-grid-search-params.js
@@ -1,0 +1,72 @@
+'use client'
+
+import {useMemo} from 'react'
+
+import {useSearchParams, useRouter} from 'next/navigation'
+
+export function useGridSearchParams({defaultSort = [{field: 'dateDepot', sort: 'desc'}]} = {}) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const initialFilterModel = useMemo(() => {
+    const filters = searchParams.get('filters')
+    if (filters) {
+      try {
+        return JSON.parse(decodeURIComponent(filters))
+      } catch {}
+    }
+
+    return {items: []}
+  }, [searchParams])
+
+  const initialSortModel = useMemo(() => {
+    const sort = searchParams.get('sort')
+    if (sort) {
+      try {
+        return JSON.parse(decodeURIComponent(sort))
+      } catch {}
+    }
+
+    return defaultSort
+  }, [searchParams, defaultSort])
+
+  const onFilterModelChange = newModel => {
+    const current = searchParams.get('filters')
+    const newValue = newModel.items?.length > 0 ? JSON.stringify(newModel) : null
+    if (current === newValue) {
+      return
+    }
+
+    const params = new URLSearchParams(searchParams.toString())
+    if (newValue) {
+      params.set('filters', newValue)
+    } else {
+      params.delete('filters')
+    }
+
+    const query = params.toString()
+    router.replace(query ? `?${query}` : window.location.pathname)
+  }
+
+  const onSortModelChange = newModel => {
+    const current = searchParams.get('sort')
+    const newValue = newModel?.length > 0 ? JSON.stringify(newModel) : null
+    if (current === newValue) {
+      return
+    }
+
+    const params = new URLSearchParams(searchParams.toString())
+    if (newValue) {
+      params.set('sort', newValue)
+    } else {
+      params.delete('sort')
+    }
+
+    const query = params.toString()
+    router.replace(query ? `?${query}` : window.location.pathname)
+  }
+
+  return {
+    initialFilterModel, initialSortModel, onFilterModelChange, onSortModelChange
+  }
+}


### PR DESCRIPTION
## Description
Cette PR extrait et unifie la logique de gestion des filtres et de l’ordre de tri des composants `<DataGrid/>` dans un hook réutilisable `useGridSearchParams`. Elle passe également le `<DataGrid/>` en mode non-contrôlé (avec `initialState`) pour éviter les boucles infinies de mises à jour lors de la synchronisation des URL search params.

### Changements
- Nouveau hook useGridSearchParams
  - Lit et décode les paramètres filters et sort depuis l’URL.
  - Expose initialFilterModel et initialSortModel pour l’initialisation du DataGrid.
  - Fournit onFilterModelChange et onSortModelChange pour mettre à jour les search params (sans provoquer de rerender cyclique).
- Refactor du composant DossiersList
  - Remplacement des états internes (useState, useEffect) par l’import du hook useGridSearchParams.
  - Passage du <DataGrid> en mode non-contrôlé via la prop initialState (incluant pagination, tri, filtre).
  - Conservation des callbacks onFilterModelChange et onSortModelChange pour mettre à jour l’URL lors des interactions.
- Correction de la boucle infinie
  - Suppression du contrôle direct des props filterModel/sortModel.
  - Ajout d’une comparaison avant router.replace pour éviter des remplacements d’URL redondants.
