### PR TITLE
Champ moisDeclaration optionnel

### DIFF
--- a/src/components/declarations/dossier/dossier-header.js
+++ b/src/components/declarations/dossier/dossier-header.js
@@ -34,7 +34,7 @@ const DossierHeader = ({numero, status, dateDepot, moisDeclaration, dsUrl}) => (
       <Box className='flex flex-wrap gap-2'>
         <Box component='span' className='fr-icon-calendar-event-fill' />
         <Typography variant='body1'>
-          Mois déclaré : {new Intl.DateTimeFormat('fr-FR', {month: 'long', year: 'numeric'}).format(new Date(moisDeclaration))}
+          Mois déclaré : {moisDeclaration ? new Intl.DateTimeFormat('fr-FR', {month: 'long', year: 'numeric'}).format(new Date(moisDeclaration)) : 'Non renseigné'}
         </Typography>
       </Box>
     </Box>


### PR DESCRIPTION
## Description
Le champ `moisDeclaration` peut ne pas exister en fonction de la version de dossier. Cette PR rend ce champ optionnel afin d'éviter des problèmes d'affichage de l'en-tête du dossier.