### PR TITLE
Distinction entre valeur nulle et zéro

### DIFF
--- a/src/utils/chart.js
+++ b/src/utils/chart.js
@@ -34,7 +34,7 @@ export function buildSeries({
         data: values.map(v => v.values[realIdx]),
         showMark: false,
         curve: 'linear',
-        valueFormatter: v => v ? formatNumber(v) : 'Aucune donnée'
+        valueFormatter: v => v === null || v === undefined ? 'Aucune donnée' : formatNumber(v)
       }
     })
 }


### PR DESCRIPTION
## Description 
le tooltip au survole du graphique multi-paramètre indique "Aucune donnée" lorsque celle-ci est en réalité à zéro.

Cette PR corrige pour n'afficher "Aucune donnée" uniquement si la valeur est `null` ou `undefined`