### PR TITLE
Amélioration de la gestion des appels à l'API

### DIFF
--- a/src/app/api/dossiers.js
+++ b/src/app/api/dossiers.js
@@ -1,30 +1,19 @@
 import {executeRequest} from './util/request.js'
 
 export async function getDossiers() {
-  const response = await executeRequest('api/dossiers')
-  return response.json()
+  return executeRequest('api/dossiers')
 }
 
 export async function getDossier(_id) {
-  const response = await executeRequest(`api/dossiers/${_id}`)
-  return response.json()
+  return executeRequest(`api/dossiers/${_id}`)
 }
 
 export async function getFile(dossierId, storageHash) {
-  const response = await executeRequest(`api/dossiers/${dossierId}/files/${storageHash}`)
-  if (!response.ok) {
-    throw new Error('Failed to fetch file')
-  }
-
-  return response.blob()
+  return executeRequest(`api/dossiers/${dossierId}/files/${storageHash}`)
 }
 
-export async function getDownloadableFile(dossierId, storageHash) {
+export async function getFileBlob(dossierId, storageHash) {
   const response = await executeRequest(`api/dossiers/${dossierId}/files/${storageHash}/download`)
-  if (!response.ok) {
-    throw new Error('Failed to fetch file')
-  }
-
   return response.blob()
 }
 
@@ -39,10 +28,6 @@ export async function validateFile(buffer, fileType) {
       body: buffer
     }
   )
-
-  if (!response.ok) {
-    throw new Error('Failed to validate file')
-  }
 
   return response.json()
 }

--- a/src/app/api/points-prelevement.js
+++ b/src/app/api/points-prelevement.js
@@ -1,134 +1,86 @@
 import {executeRequest} from './util/request.js'
 
 export async function getPointsPrelevement() {
-  const response = await executeRequest('api/points-prelevement')
-  return response.json()
+  return executeRequest('api/points-prelevement')
 }
 
 export async function getPointPrelevement(id) {
-  const response = await executeRequest(`api/points-prelevement/${id}`)
-  return response.json()
+  return executeRequest(`api/points-prelevement/${id}`)
 }
 
 export async function createPointPrelevement(payload) {
-  const response = await executeRequest('api/points-prelevement', {method: 'POST', body: payload})
-  return response.json()
+  return executeRequest('api/points-prelevement', {method: 'POST', body: payload})
 }
 
 export async function editPointPrelevement(id, payload) {
-  const response = await executeRequest(`api/points-prelevement/${id}`, {method: 'PUT', body: payload})
-  return response.json()
+  return executeRequest(`api/points-prelevement/${id}`, {method: 'PUT', body: payload})
 }
 
 export async function deletePointPrelevement(id) {
-  const response = await executeRequest(`api/points-prelevement/${id}`, {method: 'DELETE'})
-  return response.json()
+  return executeRequest(`api/points-prelevement/${id}`, {method: 'DELETE'})
 }
 
 export async function getPreleveur(id) {
-  try {
-    const response = await executeRequest(`api/preleveurs/${id}`)
-    return response.json()
-  } catch {
-    return null
-  }
+  return executeRequest(`api/preleveurs/${id}`)
 }
 
 export async function getPreleveurs() {
-  try {
-    const response = await executeRequest('api/preleveurs')
-    return response.json()
-  } catch {
-    return null
-  }
+  return executeRequest('api/preleveurs')
 }
 
 export async function getPointsFromPreleveur(idPreleveur) {
-  try {
-    const response = await executeRequest(`api/preleveurs/${idPreleveur}/points-prelevement`)
-    return response.json()
-  } catch {
-    return null
-  }
+  return executeRequest(`api/preleveurs/${idPreleveur}/points-prelevement`)
 }
 
 export async function createExploitation(payload) {
-  const response = await executeRequest(
+  return executeRequest(
     'api/exploitations',
     {method: 'POST', body: JSON.stringify(payload)}
   )
-
-  return response.json()
 }
 
 export async function updateExploitation(idExploitation, payload) {
-  const response = await executeRequest(
+  return executeRequest(
     `api/exploitations/${idExploitation}`,
     {method: 'PUT', body: JSON.stringify(payload)}
   )
-
-  return response.json()
 }
 
 export async function getExploitation(exploitationId) {
-  const response = await executeRequest(`api/exploitations/${exploitationId}`)
-  const exploitation = await response.json()
-
-  return exploitation
+  return executeRequest(`api/exploitations/${exploitationId}`)
 }
 
 export async function getExploitationsByPointId(pointId) {
-  const response = await executeRequest(`api/points-prelevement/${pointId}/exploitations`)
-  const exploitations = await response.json()
-  return exploitations
+  return executeRequest(`api/points-prelevement/${pointId}/exploitations`)
 }
 
 export async function deleteExploitation(exploitationId) {
-  const response = await executeRequest(
+  return executeRequest(
     `api/exploitations/${exploitationId}`,
     {method: 'DELETE'}
   )
-
-  return response.json()
 }
 
 export async function getStats() {
-  const response = await executeRequest('api/stats')
-  const stats = await response.json()
-
-  return stats
+  return executeRequest('api/stats')
 }
 
 export async function getVolumesExploitation(exploitationId) {
-  const response = await executeRequest(`api/exploitations/${exploitationId}/volumes-preleves`)
-  const volumes = await response.json()
-  return volumes
+  return executeRequest(`api/exploitations/${exploitationId}/volumes-preleves`)
 }
 
 export async function getBnpe() {
-  const response = await executeRequest('api/referentiels/bnpe')
-  const bnpe = await response.json()
-
-  return bnpe
+  return executeRequest('api/referentiels/bnpe')
 }
 
 export async function getMeso() {
-  const response = await executeRequest('api/referentiels/meso')
-  const meso = await response.json()
-
-  return meso
+  return executeRequest('api/referentiels/meso')
 }
 
 export async function getMeContinentales() {
-  const response = await executeRequest('api/referentiels/me-continentales-bv')
-  const meContinentales = await response.json()
-
-  return meContinentales
+  return executeRequest('api/referentiels/me-continentales-bv')
 }
 
 export async function getBvBdcarthage() {
-  const response = await executeRequest('api/referentiels/bv-bdcarthage')
-  const bvBdCarthage = await response.json()
-
-  return bvBdCarthage
+  return executeRequest('api/referentiels/bv-bdcarthage')
 }

--- a/src/app/api/util/request.js
+++ b/src/app/api/util/request.js
@@ -75,15 +75,9 @@ export async function executeRequest(urlOrOptions, moreOptions) {
     throw error
   }
 
-  // TODO : Les fonctions qui appellent executeRequest consomment encore directement
-  //        response.json(), ce qui limite la gestion fine des erreurs renvoyées par
-  //        l'API et empêche de profiter des fallbacks d'erreur de Next.js. Quand ces
-  //        fonctions auront été refactorisées pour manipuler la Response (status,
-  //        headers, etc.) avant de parser le JSON, on pourra décommenter ou adapter
-  //        le bloc ci‑dessous.
-  // if (response.headers.get('Content-Type')?.startsWith('application/json')) {
-  //   return response.json()
-  // }
+  if (response.headers.get('Content-Type')?.startsWith('application/json')) {
+    return response.json()
+  }
 
   return response
 }

--- a/src/app/dossiers/[dossierId]/page.js
+++ b/src/app/dossiers/[dossierId]/page.js
@@ -11,40 +11,23 @@ const DossierPage = async ({params}) => {
 
   const dossier = await getDossier(dossierId)
 
-  if (dossier.code === 404) {
-    return <div>Dossier non trouvable</div>
-  }
-
   let files = null
   if (dossier.files && dossier.files.length > 0) {
     files = await Promise.all(dossier.files.map(async file => {
       const [hash] = file.storageKey.split('-')
-      const fileResult = await getFile(dossierId, hash)
-      if (fileResult) {
-        // Read raw text and attempt JSON parse
-        const rawText = await fileResult.text()
-        let data
-        try {
-          data = JSON.parse(rawText)
-        } catch {
-          data = rawText
-        }
+      const data = await getFile(dossierId, hash)
 
-        data.pointsPrelevements = dossier.donneesPrelevements ? dossier.donneesPrelevements.find(point => point.fichier.storageKey === file.storageKey).pointsPrelevements : []
+      data.pointsPrelevements = dossier.donneesPrelevements ? dossier.donneesPrelevements.find(point => point.fichier.storageKey === file.storageKey).pointsPrelevements : []
 
-        return data
-      }
-
-      return null
+      return data
     }))
   }
 
   let preleveur = dossier?.demandeur
   if (dossier?.result?.preleveur) {
-    const response = await getPreleveur(dossier.result.preleveur)
-    if (response?._id) {
-      preleveur = response
-    }
+    try {
+      preleveur = await getPreleveur(dossier.result.preleveur)
+    } catch {}
   }
 
   return (
@@ -70,4 +53,3 @@ const DossierPage = async ({params}) => {
 }
 
 export default DossierPage
-

--- a/src/app/dossiers/page.js
+++ b/src/app/dossiers/page.js
@@ -1,4 +1,3 @@
-import {Alert} from '@codegouvfr/react-dsfr/Alert'
 import {CallOut} from '@codegouvfr/react-dsfr/CallOut'
 
 import {getDossiers} from '@/app/api/dossiers.js'
@@ -6,15 +5,7 @@ import DossiersList from '@/components/declarations/dossiers-list.js'
 import {StartDsfrOnHydration} from '@/dsfr-bootstrap/index.js'
 
 const Dossiers = async () => {
-  let dossiers = []
-  let error = null
-
-  try {
-    dossiers = await getDossiers()
-  } catch (error_) {
-    console.error('Erreur lors de la récupération des dossiers:', error_)
-    error = 'Une erreur est survenue lors du chargement des dossiers. Veuillez réessayer plus tard.'
-  }
+  const dossiers = await getDossiers()
 
   return (
     <>
@@ -28,16 +19,7 @@ const Dossiers = async () => {
           Consultez, filtrez et triez les dossiers déposés par les préleveurs d’eau. Identifiez rapidement les erreurs éventuelles dans les données et accédez à leur détail pour un suivi précis.
         </CallOut>
 
-        {error ? (
-          <Alert
-            closable
-            description={error}
-            severity='error'
-            title='Erreur de chargement'
-          />
-        ) : (
-          <DossiersList dossiers={dossiers} />
-        )}
+        <DossiersList dossiers={dossiers} />
       </div>
     </>
   )

--- a/src/components/declarations/dossier-details.js
+++ b/src/components/declarations/dossier-details.js
@@ -8,7 +8,7 @@ import {
 import {Box} from '@mui/material'
 import {sumBy} from 'lodash'
 
-import {getDownloadableFile} from '@/app/api/dossiers.js'
+import {getFileBlob} from '@/app/api/dossiers.js'
 import {getPointPrelevement} from '@/app/api/points-prelevement.js'
 import DossierInfos from '@/components/declarations/dossier/infos.js'
 import MandataireDetails from '@/components/declarations/dossier/mandataire-details.js'
@@ -61,7 +61,7 @@ const DossierDetails = ({dossier, preleveur, files, idPoints}) => {
     const [hash, ...filenameParts] = storageKey.split('-')
     const filename = filenameParts.join('-')
     try {
-      const file = await getDownloadableFile(dossier._id, hash)
+      const file = await getFileBlob(dossier._id, hash)
       const url = URL.createObjectURL(file)
       const a = document.createElement('a')
       a.href = url


### PR DESCRIPTION
## Description
Les fonctions qui appellent executeRequest consomment encore directement `response.json()`, ce qui limite la gestion fine des erreurs renvoyées par l'API et empêche de profiter des fallbacks d'erreur de Next.js.
Cette PR refactorisée les fonctions pour renvoyer la Response (status, headers, etc.) et parse automatique le JSON si la réponse en contient.

⚠️ Cette PR a besoin de #117 
