### PR TITLE
Amélioration de la gestion des erreurs http

### DIFF
--- a/src/app/dossiers/[dossierId]/layout.js
+++ b/src/app/dossiers/[dossierId]/layout.js
@@ -1,11 +1,22 @@
+import {notFound} from 'next/navigation'
+
 import {getDossier} from '@/app/api/dossiers.js'
 import DossiersBreadcrumb from '@/components/declarations/dossier/dossiers-breadcrumb.js'
 import {StartDsfrOnHydration} from '@/dsfr-bootstrap/index.js'
+import {parseHttpError} from '@/lib/http-error.js'
 
 const DossierPage = async ({params, children}) => {
   const {dossierId} = await params
 
-  const dossier = await getDossier(dossierId)
+  let dossier
+  try {
+    dossier = await getDossier(dossierId)
+  } catch (error) {
+    const {code} = parseHttpError(error)
+    if (code === 404) {
+      notFound()
+    }
+  }
 
   return (
     <>

--- a/src/app/error.js
+++ b/src/app/error.js
@@ -6,10 +6,12 @@ import Image from 'next/image'
 import {useRouter} from 'next/navigation'
 
 import {StartDsfrOnHydration} from '@/dsfr-bootstrap/index.js'
+import {parseHttpError} from '@/lib/http-error.js'
 
 const Error = ({error}) => {
   const router = useRouter()
-  const statusCode = error?.statusCode || 500
+
+  const {statusCode, message} = parseHttpError(error)
 
   return (
     <>
@@ -26,14 +28,14 @@ const Error = ({error}) => {
         <Box className='fr-container w-full flex flex-col gap-5'>
           <Box className='fr-container w-full flex flex-col gap-2'>
             <Typography variant='h3' className='fr-mt-3w'>
-              Erreur inattendue
+              {message}
             </Typography>
             <p> Erreur {statusCode}</p>
           </Box>
 
           <Box className='fr-container w-full flex flex-col gap-2'>
             <Typography variant='h6'>
-              Désolé, le service rencontre un problème. Nous travaillons pour le résoudre le plus rapidement possible.
+              Désolé, le service rencontre un problème&nbsp;: {message}. Nous travaillons pour le résoudre le plus rapidement possible.
             </Typography>
             <p className='fr-text--sm fr-mb-5w'>
               Essayez de rafraîchir la page ou bien ressayez plus tard.

--- a/src/app/prelevements/[id]/page.js
+++ b/src/app/prelevements/[id]/page.js
@@ -1,19 +1,26 @@
-import Loading from './loading.js'
+import {notFound} from 'next/navigation'
 
 import {getExploitationsByPointId, getPointPrelevement} from '@/app/api/points-prelevement.js'
 import PointExploitations from '@/components/prelevements/point-exploitations.js'
 import PointIdentification from '@/components/prelevements/point-identification.js'
 import PointLocalisation from '@/components/prelevements/point-localisation.js'
 import {StartDsfrOnHydration} from '@/dsfr-bootstrap/index.js'
+import {parseHttpError} from '@/lib/http-error.js'
 
 const Page = async ({params}) => {
   const {id} = (await params)
-  const pointPrelevement = await getPointPrelevement(id)
-  const exploitations = await getExploitationsByPointId(id)
 
-  if (!exploitations && !pointPrelevement) {
-    return <Loading />
+  let pointPrelevement
+  try {
+    pointPrelevement = await getPointPrelevement(id)
+  } catch (error) {
+    const {code} = parseHttpError(error)
+    if (code === 404) {
+      notFound()
+    }
   }
+
+  const exploitations = await getExploitationsByPointId(id)
 
   return (
     <>

--- a/src/app/preleveurs/[id]/page.js
+++ b/src/app/preleveurs/[id]/page.js
@@ -2,15 +2,27 @@ import {
   Alert, Box, Chip, Typography
 } from '@mui/material'
 import Link from 'next/link'
+import {notFound} from 'next/navigation'
 
 import {getPreleveur, getPointsFromPreleveur} from '@/app/api/points-prelevement.js'
 import {getUsagesColors} from '@/components/map/legend-colors.js'
 import LabelValue from '@/components/ui/label-value.js'
 import {StartDsfrOnHydration} from '@/dsfr-bootstrap/index.js'
+import {parseHttpError} from '@/lib/http-error.js'
 
 const Page = async ({params}) => {
   const {id} = await params
-  const preleveur = await getPreleveur(id)
+
+  let preleveur
+  try {
+    preleveur = await getPreleveur(id)
+  } catch (error) {
+    const {code} = parseHttpError(error)
+    if (code === 404) {
+      notFound()
+    }
+  }
+
   const points = await getPointsFromPreleveur(id)
 
   return (

--- a/src/lib/http-error.js
+++ b/src/lib/http-error.js
@@ -1,0 +1,59 @@
+/* Utility helpers to build and parse the “enriched” HTTP errors that
+   we serialise into `Error.message` so they can cross the Next.js
+   boundary. */
+
+/**
+ * Create an Error carrying a serialised payload with HTTP metadata.
+ *
+ * @param {Object} params
+ * @param {number} params.status   – HTTP status code (e.g. 404)
+ * @param {string|number} [params.code=params.status] – Business‑level error code
+ * @param {string} [params.message] – Human readable message
+ * @param {any} [params.details]   – Arbitrary extra info for debugging/UI
+ * @returns {Error} The enriched Error instance ready to be thrown
+ */
+export function createHttpError({status, code = status, message = '', details} = {}) {
+  if (!status) {
+    throw new Error('createHttpError: “status” is required')
+  }
+
+  const payload = {
+    status, code, message, details
+  }
+  const err = new Error(JSON.stringify(payload))
+  err.status = status // Keep compatibility with conventional handlers
+  return err
+}
+
+/**
+ * Extract the payload embedded by `createHttpError`.
+ *
+ * Always returns a normalised object so components can rely on the shape.
+ *
+ * @param {Error} error  – The error caught in a Route Handler / Error Boundary
+ * @returns {{status:number, code:number|string, message:string, details:any}}
+ */
+export function parseHttpError(error) {
+  let status = 500
+  let code = 500
+  let message = 'Erreur inattendue'
+  let details
+
+  // First try to decode our serialised payload
+  try {
+    const parsed = JSON.parse(error?.message ?? '{}')
+    status = parsed.status ?? status
+    code = parsed.code ?? status
+    message = parsed.message ?? message
+    details = parsed.details
+  } catch {
+    // Otherwise fall back to conventional props
+    status = error?.status ?? status
+    code = error?.code ?? status
+    message = error?.message ?? message
+  }
+
+  return {
+    status, code, message, details
+  }
+}


### PR DESCRIPTION
## Description
Cette PR complète la gestion des erreurs http à l'aide de deux helps `createHttpError` et `parseHttpError` dans `src/lib/http-error.js deux helpers`. L'objectif est de pouvoir passer le message d'erreur renvoyer par l'API jusqu'à la gestion des erreurs de notre Next app-router, mais aussi de pouvoir garder le contrôle sur la gestion des erreurs.

### Évolutions
- Redirection vers la page `not-found.js` pour les pages demandant un identifiant
- Affichage du message d'erreur dans la page d'erreur