### PR TITLE
Adaptation du header

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,5 +1,6 @@
 'use client'
 
+import {headerFooterDisplayItem} from '@codegouvfr/react-dsfr/Display'
 import {Footer as DSFRFooter} from '@codegouvfr/react-dsfr/Footer'
 import {usePathname} from 'next/navigation'
 
@@ -14,6 +15,7 @@ const FooterComponent = () => {
 
   return (
     <DSFRFooter
+      bottomItems={[headerFooterDisplayItem]}
       accessibility='fully compliant'
       contentDescription=''
     />

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -2,7 +2,6 @@
 
 import {useEffect, useState} from 'react'
 
-import {headerFooterDisplayItem} from '@codegouvfr/react-dsfr/Display'
 import {Header as DSFRHeader} from '@codegouvfr/react-dsfr/Header'
 import {usePathname} from 'next/navigation'
 import {getSession} from 'next-auth/react'
@@ -94,7 +93,6 @@ const HeaderComponent = () => {
         title: 'Accueil - Suivi des prélèvements d’eau'
       }}
       quickAccessItems={isLoadingUser ? [] : [
-        headerFooterDisplayItem,
         <LoginHeaderItem key='login' user={user} />
       ]}
       navigation={!isLoadingUser && user && (

--- a/src/components/ui/login-header-item.js
+++ b/src/components/ui/login-header-item.js
@@ -1,30 +1,77 @@
-import {HeaderQuickAccessItem} from '@codegouvfr/react-dsfr/Header'
+import Button from '@codegouvfr/react-dsfr/Button'
+import {
+  List, ListItem, Chip,
+  Typography
+} from '@mui/material'
+import Link from 'next/link'
 import {signOut} from 'next-auth/react'
 
-const LoginHeaderItem = ({id, user}) => (
-  <HeaderQuickAccessItem
-    id={id}
-    quickAccessItem={
-      user ? {
-        iconId: 'fr-icon-logout-box-r-line',
-        text: 'Se déconnecter',
-        buttonProps: {
-          onClick() {
-            signOut({
-              callbackUrl: '/login',
-              redirect: true
-            })
-          }
-        }
-      } : {
-        iconId: 'fr-icon-account-circle-line',
-        text: 'Se connecter',
-        linkProps: {
-          href: '/login'
-        }
-      }
-    }
-  />
+const LoginHeaderItem = ({user}) => (
+  <List sx={{display: 'flex', alignItems: 'center'}}>
+    {user ? (
+      <ListItem>
+        {user.prenom || user.nom ? (
+          <>
+            <Button
+              aria-expanded='false'
+              aria-controls='collapse-menu-01'
+              type='menu'
+              className='fr-nav__btn fr-mb-0 gap-1'
+            >
+              {user.prenom || user.nom ? (
+                <>
+                  <span className='fr-icon-account-circle-fill fr-icon--sm' />
+                  {user.prenom} {user.nom}
+                </>
+              ) : (
+                <>
+                  <span className='fr-icon-logout-box-r-line fr-icon--sm' aria-hidden='true' />
+                  <Typography className='fr-text--sm'>Se déconnecter</Typography>
+                </>
+              )}
+            </Button>
+
+            <div className='fr-collapse fr-menu' id='collapse-menu-01'>
+              <List className='fr-menu__list' sx={{
+                width: 'fit-content'
+              }}
+              >
+                <ListItem
+                  sx={{
+                    cursor: 'pointer',
+                    gap: 1,
+                    whiteSpace: 'nowrap'
+                  }}
+                  onClick={() => signOut({callbackUrl: '/login', redirect: true})}
+                >
+                  <span className='fr-icon-logout-box-r-line fr-icon--sm' aria-hidden='true' />
+                  <Typography className='fr-text--sm'>Se déconnecter</Typography>
+                </ListItem>
+              </List>
+            </div>
+          </>
+        ) : (
+          <Button
+            iconId='fr-icon-logout-box-r-line'
+            className='fr-text--sm'
+            onClick={() => signOut({callbackUrl: '/login', redirect: true})}
+          >
+            Se déconnecter
+          </Button>
+        )}
+
+      </ListItem>
+    ) : (
+      <ListItem>
+        <Link href='/login' className='fr-btn fr-mb-0 gap-1'>
+          <Typography className='fr-icon-account-circle-fill fr-icon--sm' aria-hidden='true' />
+          Se connecter
+        </Link>
+      </ListItem>
+    )}
+
+    {user?.isAdmin && <Chip label='Instructeur' />}
+  </List>
 )
 
 export default LoginHeaderItem


### PR DESCRIPTION
Le composant `<Header/>` évolue afin d'indiquer plus de contexte sur la session en cours une fois les informations disponibles.

Pour l'instant, nous n'avons (et n'aurons, jusqu'à ce que l'API change), qu'un bouton de connexion et de déconnexion.
Lorsque les informations propres à l'utilisateur seront disponible, son nom et son prénom seront affichés, ainsi qu'un tag `Instructeur` si celui çi est admin

### **Après récupération des informations de l'utilisateur**
<img width="1688" alt="Capture d’écran 2025-07-07 à 12 19 59" src="https://github.com/user-attachments/assets/3d10068d-8b00-4bee-bde7-a41eef144fdd" />
<img width="1691" alt="Capture d’écran 2025-07-07 à 12 20 30" src="https://github.com/user-attachments/assets/aea9596f-752b-44d3-8832-1c6efd4ab3ce" />
