### PR TITLE
Ajout d'un tooltip dans le formulaire exploitation

### DIFF
--- a/src/components/form/exploitation-form.js
+++ b/src/components/form/exploitation-form.js
@@ -3,9 +3,10 @@
 
 import {useEffect, useState} from 'react'
 
-import Input from '@codegouvfr/react-dsfr/Input'
-import SearchBar from '@codegouvfr/react-dsfr/SearchBar'
-import Select from '@codegouvfr/react-dsfr/SelectNext'
+import {Input} from '@codegouvfr/react-dsfr/Input'
+import {SearchBar} from '@codegouvfr/react-dsfr/SearchBar'
+import {Select} from '@codegouvfr/react-dsfr/SelectNext'
+import {Tooltip} from '@codegouvfr/react-dsfr/Tooltip'
 import dynamic from 'next/dynamic'
 
 import ReglesForm from './regles-form.js'
@@ -37,22 +38,10 @@ function displayPreleveur(preleveur) {
 }
 
 const statutsExploitation = [
-  {
-    label: 'En activité',
-    description: 'Exploitation qui fait actuellement encore l’objet de prélèvement.'
-  },
-  {
-    label: 'Terminée',
-    description: 'Exploitation arrêtée sans que cela soit du à une raison technique particulière.'
-  },
-  {
-    label: 'Abandonnée',
-    description: 'Il y a une raison technique qui ne permet plus l’exploitation du point de prélèvement pour l’usage visé.'
-  },
-  {
-    label: 'Non renseigné',
-    description: 'Pas d’information sur l’activité de l’exploitation.'
-  }
+  'En activité',
+  'Terminée',
+  'Abandonnée',
+  'Non renseigné'
 ]
 
 const usagesExploitation = [
@@ -168,7 +157,22 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
         />
       </div>
       <Select
-        label='Statut *'
+        label={
+          <>
+            <span className='pr-2'>Statut *</span>
+            <Tooltip
+              kind='hover'
+              title={
+                <>
+                  <p className='p-2'><b><u>En activité</u> :</b> Exploitation qui fait actuellement encore l’objet de prélèvement.</p>
+                  <p className='p-2'><b><u>Terminée</u> :</b> Exploitation arrêtée sans que cela soit dû à une raison technique particulière.</p>
+                  <p className='p-2'><b><u>Abandonnée</u> :</b> Il y a une raison technique qui ne permet plus l’exploitation du point de prélèvement pour l’usage visé (ex : contamination par les pesticides).</p>
+                  <p className='p-2'><b><u>Non renseigné</u> :</b> Pas d’information sur l’activité de l’exploitation.</p>
+                </>
+              }
+            />
+          </>
+        }
         placeholder='Sélectionner un statut'
         nativeSelectProps={{
           defaultValue: exploitation?.statut,
@@ -181,8 +185,8 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
           }
         }}
         options={statutsExploitation.map(statut => ({
-          value: statut.label,
-          label: `${statut.label} (${statut.description})`
+          value: statut,
+          label: statut
         }))}
       />
       {isStatutAbandonnee && (


### PR DESCRIPTION
Cette PR ajoute un tooltip pour afficher proprement les statuts d'exploitation.

