### PR TITLE
Validation des fichiers de déclaration de prélèvements par camion-citerne

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.0",
-    "@fabnum/prelevements-deau-timeseries-parsers": "0.0.4",
+    "@fabnum/prelevements-deau-timeseries-parsers": "0.0.6",
     "date-fns": "^4.1.0",
     "flexsearch": "^0.7.43",
     "lodash-es": "^4.17.21",

--- a/src/app/validateur/page.js
+++ b/src/app/validateur/page.js
@@ -12,7 +12,7 @@ import ValidateurResult from '@/components/declarations/validateur/result.js'
 const ValidateurPage = () => {
   const [file, setFile] = useState(null)
   const [result, setResult] = useState(null)
-  const [fileType, setFileType] = useState(null)
+  const [typePrelevement, setTypePrelevement] = useState(null)
   const [pointsPrelevement, setPointsPrelevement] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
 
@@ -21,15 +21,15 @@ const ValidateurPage = () => {
     setResult(null)
   }
 
-  const submit = async (file, fileType) => {
-    setFileType(fileType)
+  const submit = async (file, prelevementType) => {
+    setTypePrelevement(prelevementType)
     setFile(file)
     setIsLoading(true)
     try {
       const buffer = await file.arrayBuffer()
-      const validation = fileType === 'Données standardisées' ? validateMultiParamFile : validateCamionCiterneFile
+      const validation = prelevementType === 'aep-zre' ? validateMultiParamFile : validateCamionCiterneFile
       const result = await validation(buffer)
-      result.data = result.data ? (fileType === 'Données standardisées' ? [result.data] : result.data) : undefined
+      result.data = result.data ? (prelevementType === 'aep-zre' ? [result.data] : result.data) : undefined
 
       if (result.data) {
         const pointsPrelevement = await Promise.all(result.data.map(({pointPrelevement}) => getPointPrelevement(pointPrelevement)))
@@ -57,7 +57,7 @@ const ValidateurPage = () => {
           <Divider component='div' />
           <ValidateurResult
             file={file}
-            fileType={fileType}
+            typePrelevement={typePrelevement}
             pointsPrelevement={pointsPrelevement}
             data={result.data}
             errors={result.errors}

--- a/src/app/validateur/page.js
+++ b/src/app/validateur/page.js
@@ -13,7 +13,7 @@ const ValidateurPage = () => {
   const [file, setFile] = useState(null)
   const [result, setResult] = useState(null)
   const [fileType, setFileType] = useState(null)
-  const [pointPrelevement, setPointPrelevement] = useState(null)
+  const [pointsPrelevement, setPointsPrelevement] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
 
   const resetForm = () => {
@@ -29,13 +29,14 @@ const ValidateurPage = () => {
       const buffer = await file.arrayBuffer()
       const validation = fileType === 'Données standardisées' ? validateMultiParamFile : validateCamionCiterneFile
       const result = await validation(buffer)
+      result.data = result.data ? (fileType === 'Données standardisées' ? [result.data] : result.data) : undefined
+
+      if (result.data) {
+        const pointsPrelevement = await Promise.all(result.data.map(({pointPrelevement}) => getPointPrelevement(pointPrelevement)))
+        setPointsPrelevement(pointsPrelevement)
+      }
 
       setResult(result)
-
-      if (result.data.pointPrelevement) {
-        const pointPrelevement = await getPointPrelevement(result.data.pointPrelevement)
-        setPointPrelevement(pointPrelevement)
-      }
     } catch (error) {
       console.error('Erreur lors de la validation du fichier:', error)
     }
@@ -57,7 +58,7 @@ const ValidateurPage = () => {
           <ValidateurResult
             file={file}
             fileType={fileType}
-            pointPrelevement={pointPrelevement}
+            pointsPrelevement={pointsPrelevement}
             data={result.data}
             errors={result.errors}
           />

--- a/src/components/declarations/dossier-details.js
+++ b/src/components/declarations/dossier-details.js
@@ -124,7 +124,7 @@ const DossierDetails = ({dossier, preleveur, files, idPoints}) => {
       <PrelevementsDetails
         volumePrelevementTotal={volumePrelevementTotal}
         moisDeclaration={dossier.moisDeclaration}
-        tableauSuiviPrelevements={dossier.tableauSuiviPrelevements}
+        typePrelevement={dossier.typePrelevement}
         pointsPrelevementId={idPoints}
         pointsPrelevement={pointsPrelevement}
         selectedPointId={selectedPointId}

--- a/src/components/declarations/dossier/prelevements-details.js
+++ b/src/components/declarations/dossier/prelevements-details.js
@@ -69,7 +69,7 @@ const sortFilesByPointPrelevement = (files, pointsPrelevement) => {
 const PrelevementsDetails = ({
   volumePrelevementTotal,
   moisDeclaration,
-  tableauSuiviPrelevements,
+  typePrelevement,
   pointsPrelevement,
   selectedPointId,
   relevesIndex,
@@ -129,8 +129,12 @@ const PrelevementsDetails = ({
                 status={file?.result.errors?.length > 0 || !file.result.data ? 'error' : 'success'}
                 handleSelect={() => selectedPoint(poinPrelevementId)}
               >
-                {tableauSuiviPrelevements && (
-                  <Alert severity='info' description=' Ce type de dossier n’est pas encore pris en charge.' />
+                {typePrelevement === 'camion-citerne' && (
+                  <Alert
+                    className='mb-4'
+                    severity='info'
+                    description='Ce type de dossier n’est pas encore pris en charge.'
+                  />
                 )}
 
                 <Spreadsheet
@@ -139,6 +143,7 @@ const PrelevementsDetails = ({
                   data={file.result?.data || {}}
                   errors={file.result?.errors}
                   downloadFile={handleDownload}
+                  typePrelevement={typePrelevement}
                 />
               </PrelevementsAccordion>
             </Box>
@@ -153,7 +158,7 @@ const PrelevementsDetails = ({
   }, [
     volumePrelevementTotal,
     moisDeclaration,
-    tableauSuiviPrelevements,
+    typePrelevement,
     pointsPrelevement,
     selectedPointId,
     relevesIndex,

--- a/src/components/declarations/dossier/prelevements/parameter-trend-chart.js
+++ b/src/components/declarations/dossier/prelevements/parameter-trend-chart.js
@@ -160,7 +160,7 @@ const ParameterTrendChart = ({data, connectNulls}) => {
       label: u,
       position: i === 0 ? 'left' : 'right',
       min: 0,
-      valueFormatter: v => formatNumber(v, {maximumFractionDigits: v > 10 ? 0 : 1})
+      valueFormatter: v => formatNumber(v, v < 1 ? {maximumFractionDigits: 2, minimumFractionDigits: 2} : {})
     })),
   [axisUnits])
 

--- a/src/components/declarations/dossier/prelevements/parameter-trend-chart.js
+++ b/src/components/declarations/dossier/prelevements/parameter-trend-chart.js
@@ -18,7 +18,7 @@ import {uniqBy} from 'lodash-es'
 import {buildSeries} from '@/utils/chart.js'
 import {formatNumber} from '@/utils/number.js'
 
-const ParameterTrendChart = ({data}) => {
+const ParameterTrendChart = ({data, connectNulls}) => {
   // ---------- Données brutes ----------
   const {
     dailyValues = [], dailyParameters = [],
@@ -137,8 +137,10 @@ const ParameterTrendChart = ({data}) => {
     parameters: visibleParameters,
     allParameters: parameters,
     values: slicedValues,
-    unitToAxisId
-  }), [visibleParameters, parameters, slicedValues, unitToAxisId])
+    unitToAxisId,
+    showMark: slicedValues.length <= 31,
+    connectNulls
+  }), [visibleParameters, parameters, slicedValues, unitToAxisId, connectNulls])
 
   const series = useMemo(
     () => rawSeries.map(s => {

--- a/src/components/declarations/dossier/prelevements/prelevements-accordion.js
+++ b/src/components/declarations/dossier/prelevements/prelevements-accordion.js
@@ -49,7 +49,7 @@ const PrelevementsAccordion = ({idPoint, pointPrelevement, volumePreleveTotal = 
         </Box>
 
         <Badge severity={status}>
-          {status === 'success' ? 'OK' : 'Anomalie'}
+          {status === 'success' ? 'OK' : (status === 'warning' ? 'Anomalie' : 'Erreur')}
         </Badge>
       </Box>
     </AccordionSummary>

--- a/src/components/declarations/dossier/prelevements/spreadsheet.js
+++ b/src/components/declarations/dossier/prelevements/spreadsheet.js
@@ -36,57 +36,57 @@ const Spreadsheet = ({moisDeclaration, storageKey = '', data = {}, errors, typeP
 
   return (
     <Box className='flex flex-col gap-6'>
-      {data && (
-        <>
-          <Box className='flex flex-col gap-4'>
-            <Divider textAlign='left'>
-              Paramètres par pas de temps
-            </Divider>
+      <Box className='flex flex-col gap-4'>
+        <Divider textAlign='left'>
+          Paramètres par pas de temps
+        </Divider>
 
-            <Box className='flex flex-col gap-2'>
-              {data.dailyParameters && (
-                <Box className='flex flex-wrap gap-1 items-center'>
-                  Journalier : {data.dailyParameters.map(param => (
-                    <Tag key={param.paramIndex} sx={{m: 1}}>
-                      {param.nom_parametre} ({param.unite})
-                    </Tag>
-                  ))}
-                </Box>
-              )}
-
-              {data.fifteenMinutesParameters && (
-                <Box className='flex flex-wrap gap-1 items-center'>
-                  Quinze minutes : {data.fifteenMinutesParameters.map(param => (
-                    <Tag key={param.paramIndex} sx={{m: 1}}>
-                      {param.nom_parametre} ({param.unite})
-                    </Tag>
-                  ))}
-                </Box>
-              )}
+        <Box className='flex flex-col gap-2'>
+          {data.dailyParameters ? (
+            <Box className='flex flex-wrap gap-1 items-center'>
+              Journalier : {data.dailyParameters.map(param => (
+                <Tag key={param.paramIndex} sx={{m: 1}}>
+                  {param.nom_parametre} ({param.unite})
+                </Tag>
+              ))}
             </Box>
-          </Box>
+          ) : (
+            <Alert severity='warning' description='Aucun paramètre journalier renseigné.' />
+          )}
 
-          <Box className='flex flex-col gap-4'>
-            <Divider textAlign='left'>
-              Calendrier des prélèvements
-            </Divider>
+          {data.fifteenMinutesParameters && (
+            <Box className='flex flex-wrap gap-1 items-center'>
+              Quinze minutes : {data.fifteenMinutesParameters.map(param => (
+                <Tag key={param.paramIndex} sx={{m: 1}}>
+                  {param.nom_parametre} ({param.unite})
+                </Tag>
+              ))}
+            </Box>
+          )}
+        </Box>
+      </Box>
 
-            {hasDatesOutsideDeclMonth && (
-              <Alert
-                severity='warning'
-                className='mb-2'
-                description={
-                  <>
-                    Certaines dates de prélèvement ne sont pas situées dans le mois déclaré : {new Intl.DateTimeFormat('fr-FR', {month: 'long', year: 'numeric'}).format(new Date(moisDeclaration))}
-                  </>
-                }
-              />
-            )}
+      {Object.keys(data).length > 0 && (
+        <Box className='flex flex-col gap-4'>
+          <Divider textAlign='left'>
+            Calendrier des prélèvements
+          </Divider>
 
-            <PrelevementsCalendar data={data} />
-            <ParameterTrendChart data={data} connectNulls={typePrelevement === 'camion-citerne'} />
-          </Box>
-        </>
+          {hasDatesOutsideDeclMonth && (
+            <Alert
+              severity='warning'
+              className='mb-2'
+              description={
+                <>
+                  Certaines dates de prélèvement ne sont pas situées dans le mois déclaré : {new Intl.DateTimeFormat('fr-FR', {month: 'long', year: 'numeric'}).format(new Date(moisDeclaration))}
+                </>
+              }
+            />
+          )}
+
+          <PrelevementsCalendar data={data} />
+          <ParameterTrendChart data={data} connectNulls={typePrelevement === 'camion-citerne'} />
+        </Box>
       )}
 
       {errors && (

--- a/src/components/declarations/dossier/prelevements/spreadsheet.js
+++ b/src/components/declarations/dossier/prelevements/spreadsheet.js
@@ -13,7 +13,7 @@ import ParameterTrendChart from '@/components/declarations/dossier/prelevements/
 import FileValidationErrors from '@/components/declarations/file-validation-errors.js'
 import PrelevementsCalendar from '@/components/declarations/prelevements-calendar.js'
 
-const Spreadsheet = ({moisDeclaration, storageKey = '', data = {}, errors, downloadFile}) => {
+const Spreadsheet = ({moisDeclaration, storageKey = '', data = {}, errors, typePrelevement = 'aep-zre', downloadFile}) => {
   const [, ...filename] = storageKey.split('-')
 
   // Vérifie si les dates de prélèvement (minDate / maxDate) se situent dans le mois déclaré
@@ -84,7 +84,7 @@ const Spreadsheet = ({moisDeclaration, storageKey = '', data = {}, errors, downl
             )}
 
             <PrelevementsCalendar data={data} />
-            <ParameterTrendChart data={data} />
+            <ParameterTrendChart data={data} connectNulls={typePrelevement === 'camion-citerne'} />
           </Box>
         </>
       )}

--- a/src/components/declarations/file-validation-errors.js
+++ b/src/components/declarations/file-validation-errors.js
@@ -117,7 +117,7 @@ const FileValidationErrors = ({errors: errorList}) => {
                   </Box>
                 </AccordionDetails>
               ) : (
-                <Alert severity='info' description='Pas d’autre information disponible.' />
+                <Alert severity='info' description={item.explanation || 'Pas d’autre information disponible.'} />
               )}
             </Accordion>
           )

--- a/src/components/declarations/month-prevelement-calendar.js
+++ b/src/components/declarations/month-prevelement-calendar.js
@@ -42,7 +42,7 @@ const DayCell = ({day, firstDayCurrentMonth, dataMap, renderTooltipContent, onDa
     dayStyleEntry: dayData
   }
 
-  const isClickable = isCurrentMonthDay && dayData
+  const isClickable = onDayClick && isCurrentMonthDay && dayData
 
   const cellMarkup = (
     <div

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -120,7 +120,7 @@ const PrelevementsCalendar = ({data}) => {
             </>
           )
         }}
-        onDayClick={fifteenValues ? handleDayClick : undefined}
+        onDayClick={fifteenValues.length > 0 ? handleDayClick : undefined}
       />
 
       <Modal open={open} onClose={handleClose}>

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -78,7 +78,7 @@ const PrelevementsCalendar = ({data}) => {
 
   const handleClose = () => setOpen(false)
 
-  if (data.dailyValues.length === 0) {
+  if (data.dailyValues && data.dailyValues.length === 0) {
     return (
       <Alert severity='warning' description='Aucune donnée de prélèvement n’a été trouvée.' />
     )
@@ -120,7 +120,7 @@ const PrelevementsCalendar = ({data}) => {
             </>
           )
         }}
-        onDayClick={handleDayClick}
+        onDayClick={fifteenValues ? handleDayClick : undefined}
       />
 
       <Modal open={open} onClose={handleClose}>

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -100,13 +100,8 @@ const PrelevementsCalendar = ({data}) => {
             )
           }
 
-          const {values, fifteenMinutesValues} = dayStyleEntry
-          const warnings = values.map((v, i) => {
-            const dailyMissing = v === null
-            const fifteenMissing = !Array.isArray(fifteenMinutesValues)
-              || fifteenMinutesValues.some(slot => slot.values[i] === null)
-            return dailyMissing || fifteenMissing
-          })
+          const {values} = dayStyleEntry
+          const warnings = values.map(v => v === null || v === undefined || v < 0)
 
           return (
             <>

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -108,7 +108,9 @@ const PrelevementsCalendar = ({data}) => {
               <strong>{date.toLocaleDateString('fr-FR')}</strong>
               {Object.keys(data.dailyParameters).map(paramIndex => (
                 <Typography key={paramIndex}>
-                  {data.dailyParameters[paramIndex].nom_parametre} : {values[paramIndex] ? formatNumber(values[paramIndex]) : '—'} m³
+                  {data.dailyParameters[paramIndex].nom_parametre} : {Number.isNaN(values[paramIndex])
+                    ? '—'
+                    : formatNumber(values[paramIndex], values[paramIndex] < 1 && values[paramIndex] !== 0 ? {maximumFractionDigits: 2, minimumFractionDigits: 2} : {})} m³
                   {warnings[0] && <Box component='span' className='fr-icon-warning-fill' />}
                 </Typography>
               ))}
@@ -134,9 +136,11 @@ const PrelevementsCalendar = ({data}) => {
               <Box className='flex gap-2'>
                 {data.dailyParameters.map((param, idx) => (
                   <Typography key={param.paramIndex}>
-                    {param.nom_parametre}: {selectedDayInfo.dayStyleEntry.values[idx]
-                      ? formatNumber(selectedDayInfo.dayStyleEntry.values[idx], {maximumFractionDigits: 2})
-                      : '—'} {param.unite}
+                    {param.nom_parametre}: {
+                      Number.isNaN(selectedDayInfo.dayStyleEntry.values[idx])
+                        ? '—'
+                        : formatNumber(selectedDayInfo.dayStyleEntry.values[idx], {maximumFractionDigits: 2})
+                    } {param.unite}
                   </Typography>
                 ))}
               </Box>

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -14,32 +14,29 @@ import {fr as locale} from 'date-fns/locale'
 import CalendarGrid from '@/components/calendar-grid.js'
 import {formatNumber} from '@/utils/number.js'
 
-function determineColors(values, fifteenMinutesValues) {
-  const nParams = values.length
-  const dailyComplete = values.map(v => v !== null && v !== undefined)
-  const hasDaily = dailyComplete.some(Boolean)
-  if (!hasDaily) {
-    // Aucune valeur journalière renseignée
-    return {colorA: 'grey', colorB: null}
+function determineColors(values, fifteenMinutesValues, dailyParameters) {
+  const hasNegativeValue = values.some(v => v < 0)
+  if (hasNegativeValue) {
+    return {colorA: fr.colors.decisions.background.flat.error.default, colorB: null}
   }
 
-  // Vérifie que chaque paramètre a toutes les valeurs 15min
-  const fifteenComplete = values.map((_, i) =>
-    Array.isArray(fifteenMinutesValues)
-    && fifteenMinutesValues.length > 0
-    && fifteenMinutesValues.every(slot =>
-      slot.values && slot.values[i] !== null && slot.values[i] !== undefined
-    )
-  )
-  // Un paramètre est complet si le journalier ET les 15min sont complets
-  const completeParams = dailyComplete.map((d, i) => d && fifteenComplete[i])
-  const nComplete = completeParams.filter(Boolean).length
-  if (nComplete === nParams) {
-    // Toutes les données sont complètes
+  const volumePreleveParam = dailyParameters?.find(p => p.nom_parametre === 'volume prélevé')
+  const volumePreleveIndex = volumePreleveParam ? dailyParameters.indexOf(volumePreleveParam) : -1
+
+  const hasAnyData = values.some(v => Number.isNaN(v)) || (fifteenMinutesValues?.length > 0)
+
+  if (volumePreleveIndex > -1 && !Number.isNaN(values[volumePreleveIndex])) {
+    // Bleu si la donnée journalière pour le volume prélevé est présente
     return {colorA: fr.colors.decisions.text.actionHigh.blueFrance.default, colorB: null}
   }
 
-  return {colorA: fr.colors.decisions.background.flat.warning.default}
+  if (hasAnyData) {
+    // Orange s'il y a d'autres données mais pas le volume prélevé journalier
+    return {colorA: fr.colors.decisions.background.flat.warning.default, colorB: null}
+  }
+
+  // Gris si aucune donnée
+  return {colorA: 'grey', colorB: null}
 }
 
 export function transformOutJsonToCalendarData(outJson) {
@@ -47,7 +44,7 @@ export function transformOutJsonToCalendarData(outJson) {
   return daily.map(({date, values, fifteenMinutesValues}) => {
     // Reformattage de la date pour dd-MM-yyyy
     const dateKey = format(parseISO(date), 'dd-MM-yyyy')
-    const {colorA, colorB} = determineColors(values, fifteenMinutesValues)
+    const {colorA, colorB} = determineColors(values, fifteenMinutesValues, outJson.dailyParameters)
     return {
       date: dateKey,
       values,

--- a/src/components/declarations/validateur/form.js
+++ b/src/components/declarations/validateur/form.js
@@ -10,7 +10,7 @@ import {
 
 const FileValidateurForm = ({isLoading, resetForm, handleSubmit}) => {
   const [file, setFile] = useState(null)
-  const [fileType, setFileType] = useState('Données standardisées')
+  const [fileType, setFileType] = useState('aep-zre')
   const [inputError, setInputError] = useState(null)
 
   const handleFileChange = useEventCallback(event => {
@@ -44,8 +44,8 @@ const FileValidateurForm = ({isLoading, resetForm, handleSubmit}) => {
         }}
       >
         <option disabled hidden value=''>Selectionnez un type de fichier</option>
-        <option value='Données standardisées'>Données standardisées</option>
-        <option value='Tableau de suivi'>Tableau de suivi</option>
+        <option value='aep-zre'>Données standardisées</option>
+        <option value='camion-citerne'>Tableau de suivi</option>
       </Select>
 
       <Upload

--- a/src/components/declarations/validateur/form.js
+++ b/src/components/declarations/validateur/form.js
@@ -45,7 +45,7 @@ const FileValidateurForm = ({isLoading, resetForm, handleSubmit}) => {
       >
         <option disabled hidden value=''>Selectionnez un type de fichier</option>
         <option value='Données standardisées'>Données standardisées</option>
-        <option disabled value='Tableau de suivi'>Tableau de suivi (à venir)</option>
+        <option value='Tableau de suivi'>Tableau de suivi</option>
       </Select>
 
       <Upload

--- a/src/components/declarations/validateur/result.js
+++ b/src/components/declarations/validateur/result.js
@@ -11,7 +11,7 @@ import Spreadsheet from '@/components/declarations/dossier/prelevements/spreadsh
 import FileValidationErrors from '@/components/declarations/file-validation-errors.js'
 import {formatBytes} from '@/utils/size.js'
 
-const ValidateurResult = ({file, fileType, pointsPrelevement, data, errors = []}) => {
+const ValidateurResult = ({file, typePrelevement, pointsPrelevement, data, errors = []}) => {
   const [selectedPointId, setSelectedPointId] = useState(data?.length === 1 ? data[0].pointPrelevement : null)
 
   const hasError = errors.some(({severity}) => severity === 'error')

--- a/src/components/declarations/validateur/result.js
+++ b/src/components/declarations/validateur/result.js
@@ -1,3 +1,5 @@
+import {useState} from 'react'
+
 import {Alert} from '@codegouvfr/react-dsfr/Alert'
 import {
   Card, CardContent, Typography
@@ -9,8 +11,8 @@ import Spreadsheet from '@/components/declarations/dossier/prelevements/spreadsh
 import FileValidationErrors from '@/components/declarations/file-validation-errors.js'
 import {formatBytes} from '@/utils/size.js'
 
-const ValidateurResult = ({file, fileType, pointPrelevement, data, errors = []}) => {
-  const noError = errors.length === 0
+const ValidateurResult = ({file, fileType, pointsPrelevement, data, errors = []}) => {
+  const [selectedPointId, setSelectedPointId] = useState(data?.length === 1 ? data[0].pointPrelevement : null)
   return (
     <Box className='flex flex-col gap-4'>
       <Alert
@@ -35,23 +37,26 @@ const ValidateurResult = ({file, fileType, pointPrelevement, data, errors = []})
         )}
 
         {data && (
-          <PrelevementsAccordion
-            isOpen
-            idPoint={data.pointPrelevement}
-            pointPrelevement={pointPrelevement}
-            volumePreleveTotal={data.volumePreleveTotal}
-            status={errors?.length > 0 || !data ? 'error' : 'success'}
-          >
-            {fileType === 'Données standardisées' ? (
-              <Spreadsheet
-                data={data}
-                errors={errors}
-              />
-            ) : (
-              <Alert severity='info' description=' Ce type de dossier n’est pas encore pris en charge.' />
-            )}
+          data.map(d => {
+            const poinPrelevementId = d?.pointPrelevement || pointsPrelevement[0]
 
-          </PrelevementsAccordion>
+            return (
+              <PrelevementsAccordion
+                key={d.pointPrelevement}
+                isOpen={selectedPointId === poinPrelevementId}
+                idPoint={d.pointPrelevement}
+                pointPrelevement={pointsPrelevement.find(p => p.id_point === d.pointPrelevement)}
+                volumePreleveTotal={d.volumePreleveTotal}
+                status={status}
+                handleSelect={() => setSelectedPointId(poinPrelevementId)}
+              >
+                <Spreadsheet
+                  data={d}
+                  errors={errors}
+                />
+              </PrelevementsAccordion>
+            )
+          })
         )}
       </Card>
     </Box>

--- a/src/components/declarations/validateur/result.js
+++ b/src/components/declarations/validateur/result.js
@@ -67,6 +67,7 @@ const ValidateurResult = ({file, typePrelevement, pointsPrelevement, data, error
                 <Spreadsheet
                   data={d}
                   errors={errors}
+                  typePrelevement={typePrelevement}
                 />
               </PrelevementsAccordion>
             )

--- a/src/components/declarations/validateur/result.js
+++ b/src/components/declarations/validateur/result.js
@@ -13,14 +13,28 @@ import {formatBytes} from '@/utils/size.js'
 
 const ValidateurResult = ({file, fileType, pointsPrelevement, data, errors = []}) => {
   const [selectedPointId, setSelectedPointId] = useState(data?.length === 1 ? data[0].pointPrelevement : null)
+
+  const hasError = errors.some(({severity}) => severity === 'error')
+  const hasWarning = errors.some(({severity}) => severity === 'warning')
+  const status = hasError ? 'error' : (hasWarning ? 'warning' : 'success')
+
   return (
     <Box className='flex flex-col gap-4'>
-      <Alert
-        closable={false}
-        title={noError ? 'Le fichier est valide' : 'Le fichier est invalide'}
-        description={noError ? 'Aucune erreur détectée' : `Le fichier contient ${errors.length} erreur${errors.length > 1 ? 's' : ''}`}
-        severity={noError ? 'success' : 'error'}
-      />
+      {hasError ? (
+        <Alert
+          closable={false}
+          title='Le fichier est invalide'
+          description={`Le fichier contient ${errors.length} erreur${errors.length > 1 ? 's' : ''}`}
+          severity='error'
+        />
+      ) : (
+        <Alert
+          closable={false}
+          title={hasWarning ? 'Le fichier contient des avertissements' : 'Le fichier est valide'}
+          description={hasWarning ? `Le fichier contient ${errors.length} avertissement${errors.length > 1 ? 's' : ''}` : 'Aucune erreur détectée'}
+          severity={hasWarning ? 'warning' : 'success'}
+        />
+      )}
 
       <Card variant='outlined'>
         <CardContent>

--- a/src/utils/chart.js
+++ b/src/utils/chart.js
@@ -16,7 +16,9 @@ export function buildSeries({
   parameters, // Paramètres visibles (sélectionnés)
   allParameters, // Liste complète des paramètres pour la granularité courante
   values,
-  unitToAxisId // { 'm³/h': 'left', 'µS/cm': 'right' }
+  unitToAxisId, // { 'm³/h': 'left', 'µS/cm': 'right' }
+  connectNulls = false,
+  showMark = false
 }) {
   // Retirer les entrées nulles et dédupliquer par nom_parametre
   const dedupedParams = uniqBy(parameters.filter(Boolean), 'nom_parametre')
@@ -32,7 +34,8 @@ export function buildSeries({
         label: `${p.nom_parametre} (${p.unite})`,
         yAxisKey: unitToAxisId[p.unite],
         data: values.map(v => v.values[realIdx]),
-        showMark: false,
+        showMark,
+        connectNulls,
         curve: 'linear',
         valueFormatter: v => v === null || v === undefined ? 'Aucune donnée' : formatNumber(v)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,14 +364,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fabnum/prelevements-deau-timeseries-parsers@npm:0.0.4":
-  version: 0.0.4
-  resolution: "@fabnum/prelevements-deau-timeseries-parsers@npm:0.0.4"
+"@fabnum/prelevements-deau-timeseries-parsers@npm:0.0.6":
+  version: 0.0.6
+  resolution: "@fabnum/prelevements-deau-timeseries-parsers@npm:0.0.6"
   dependencies:
     file-type: "npm:^21.0.0"
     lodash-es: "npm:^4.17.21"
     xlsx: "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
-  checksum: 10c0/2f5a464a3af9c3027d6dc0701da8c95639d4a5184fd01f72195b84b88a52d4021b379ee209d93e5ac9b2855b573ed501f570e79fa35daf5921815b4ee89c8de3
+  checksum: 10c0/32f42234b97b73367d4d673b7cfcac4b397159fc15acc061ebd3af763e925b8b866fe95ddbb12b07e467e7e0813356161930535b67453e8286ec4674cc588eda
   languageName: node
   linkType: hard
 
@@ -6026,7 +6026,7 @@ __metadata:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/server": "npm:^11.11.0"
     "@emotion/styled": "npm:^11.14.0"
-    "@fabnum/prelevements-deau-timeseries-parsers": "npm:0.0.4"
+    "@fabnum/prelevements-deau-timeseries-parsers": "npm:0.0.6"
     "@mui/icons-material": "npm:^6.4.10"
     "@mui/material": "npm:^6.4.10"
     "@mui/material-nextjs": "npm:^6.4.3"


### PR DESCRIPTION
## Description
Cette pull request introduit la prise en charge de la validation des fichiers de déclaration de prélèvements par camion-citerne.

Les changements principaux sont les suivants :

**Nouveau type de validation "camion-citerne"** :
- Ajout d’un nouveau type de fichier "Tableau de suivi" dans le validateur, utilisant la fonction de validation `validateCamionCiterneFile`.
- Mise à jour du formulaire de validation pour permettre la sélection de ce nouveau type.

**Amélioration de l'affichage des résultats de validation** :
- La page de résultats du validateur a été adaptée pour afficher les informations spécifiques aux fichiers de type "camion-citerne".
- Le graphique de tendance connecte désormais les valeurs nulles pour les données de ce type.

**Mise à jour de la page de détails des dossiers** :
- La logique a été adaptée pour gérer les fichiers contenant plusieurs points de prélèvement.

**Amélioration de l'affichage des erreurs**:
- Le composant d’affichage des erreurs de validation a été amélioré avec une fonctionnalité "voir plus/moins" pour une meilleure lisibilité des longues listes d’erreurs.

**Autres changements**
- Mise à jour de `@fabnum/prelevements-deau-timeseries-parsers` en v0.0.6