### PR TITLE
Ajoute le statut de validation d'un dossier

### DIFF
--- a/src/components/declarations/dossiers-list.js
+++ b/src/components/declarations/dossiers-list.js
@@ -13,6 +13,8 @@ import {useRouter} from 'next/navigation'
 import DossierStateBadge from '@/components/declarations/dossier-state-badge.js'
 import PrelevementTypeBadge from '@/components/declarations/prelevement-type-badge.js'
 import TypeSaisieBadge from '@/components/declarations/type-saisie-badge.js'
+import ValidationStatus from '@/components/declarations/validation-status.js'
+import {validationStatus} from '@/lib/dossier.js'
 import {getDossierURL} from '@/lib/urls.js'
 import {normalizeName} from '@/utils/string.js'
 
@@ -27,7 +29,8 @@ const convertDossierToRow = dossier => ({
   commentaires: dossier.commentaires,
   numeroArreteAot: dossier.numeroArreteAot,
   typeDonnees: dossier.typeDonnees,
-  moisDeclaration: dossier.moisDeclaration
+  moisDeclaration: dossier.moisDeclaration,
+  validationStatus: dossier.validationStatus
 })
 
 function renderMonthCell(value) {
@@ -120,6 +123,17 @@ const DossiersList = ({dossiers}) => {
               {value: 'accepte', label: 'Accepté'},
               {value: 'en-instruction', label: 'En instruction'},
               {value: 'en-construction', label: 'En construction'}
+            ]
+          },
+          {
+            field: 'validationStatus',
+            headerName: 'Vérification',
+            width: 200,
+            renderCell: ValidationStatus,
+            type: 'singleSelect',
+            valueOptions: [
+              ...Object.keys(validationStatus).map(key => ({value: key, label: validationStatus[key]})),
+              {value: null, label: 'Non vérifié'}
             ]
           },
           {

--- a/src/components/declarations/validation-status.js
+++ b/src/components/declarations/validation-status.js
@@ -1,0 +1,10 @@
+import {Badge} from '@codegouvfr/react-dsfr/Badge'
+
+import {validationStatus} from '@/lib/dossier.js'
+
+const DossierValidationStatus = ({value}) => {
+  const label = validationStatus[value]
+  return <Badge severity={value}>{label || 'Non vérifié'}</Badge>
+}
+
+export default DossierValidationStatus

--- a/src/lib/dossier.js
+++ b/src/lib/dossier.js
@@ -1,3 +1,10 @@
+export const validationStatus = {
+  success: 'Succès',
+  error: 'Erreur',
+  warning: 'Avertissement',
+  failed: 'Échec'
+}
+
 export function getPointsPrelevementId(dossier) {
   if (dossier.pointPrelevement) {
     return [dossier.pointPrelevement]


### PR DESCRIPTION
## Description
Ajout du  statut de validation d'un dossier issue de la validation de ses fichiers associés. Cette évolution permet de mettre en avant les dossiers plus d'attention.
À terme, ce statut permettra également d'alimenter un tableau de bord dédié par exemple.

### Preview
<img width="1197" height="472" alt="Capture d’écran 2025-07-24 à 16 24 25" src="https://github.com/user-attachments/assets/22d45d17-c25a-4d70-9700-5e9c3a0be642" />
