### PR TITLE
Publication de Storybook sur GitHub Pages

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,31 @@
+name: Build and Publish Storybook to GitHub Pages
+
+on:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Manual Checkout
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Set up Node
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      #👇 Add Storybook build and deploy to GitHub Pages as a step in the workflow
+      - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
+        with:
+          install_command: yarn --immutable
+          build_command: yarn build-storybook
+          path: storybook-static
+          checkout: false


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate building and publishing the Storybook documentation to GitHub Pages whenever changes are pushed to the `main` branch.

**CI/CD Automation:**

* Added a `.github/workflows/storybook.yml` workflow that checks out the repository, sets up Node.js, builds Storybook, and deploys the generated static site to GitHub Pages on pushes to `main`.