### PR TITLE
Suppression de l'orange d'avertissement — remplacement par bleu clair (cas "warning" retiré)

### DIFF
--- a/src/components/ui/CalendarGrid/calendar-grid.stories.js
+++ b/src/components/ui/CalendarGrid/calendar-grid.stories.js
@@ -5,7 +5,7 @@ import CalendarGrid from './index.js'
 import PeriodTooltip from '@/components/ui/PeriodTooltip/index.js'
 
 const blue = fr.colors.decisions.artwork.major.blueFrance.default
-const orange = fr.colors.decisions.background.actionHigh.warning.hover
+const lightBlue = fr.colors.decisions.background.actionHigh.info.hover
 
 // Build a full year: one calendar ("month" mode) per month with a single colored day
 const buildYearCalendars = (year, color1, color2) => {
@@ -38,7 +38,7 @@ const meta = {
     }
   },
   args: {
-    calendars: buildYearCalendars(2025, blue, orange)
+    calendars: buildYearCalendars(2025, blue, lightBlue)
   }
 }
 
@@ -72,23 +72,23 @@ export const PlusieursCalendriersMemeMode = {
     calendars: [
       [
         {date: '2026-01', color: blue, label: 'Jan'},
-        {date: '2026-04', color: orange, label: 'Avril'},
+        {date: '2026-04', color: lightBlue, label: 'Avril'},
         {date: '2026-07', color: blue, label: 'Juil'}
       ],
       [
         {date: '2025-02', color: blue},
-        {date: '2025-05', color: orange},
+        {date: '2025-05', color: lightBlue},
         {date: '2025-08', color: blue}
       ],
       [
-        {date: '2024-03', color: orange},
+        {date: '2024-03', color: lightBlue},
         {date: '2024-06', color: blue},
         {date: '2024-09', color: blue},
-        {date: '2024-12', color: orange}
+        {date: '2024-12', color: lightBlue}
       ],
       [
         {date: '2023-01', color: blue},
-        {date: '2023-05', color: orange},
+        {date: '2023-05', color: lightBlue},
         {date: '2023-11', color: blue}
       ]
     ],
@@ -104,12 +104,12 @@ export const CustomLegend = {
     calendars: [
       [
         {date: '2025-07-01', color: blue, volume: 10},
-        {date: '2025-07-02', color: orange, volume: 12}
+        {date: '2025-07-02', color: lightBlue, volume: 12}
       ]
     ],
     legendLabels: [
       {color: blue, label: 'OK'},
-      {color: orange, label: 'Alerte'}
+      {color: lightBlue, label: 'Alerte'}
     ],
     hoverComponent: Hover
   }
@@ -123,11 +123,11 @@ export const Interaction = {
     calendars: [
       [
         {date: '2026-07-01', color: blue, label: 'Jour 1'},
-        {date: '2026-07-05', color: orange, label: 'Jour 5'}
+        {date: '2026-07-05', color: lightBlue, label: 'Jour 5'}
       ],
       [
         {date: '2026-01', color: blue, label: 'Janvier'},
-        {date: '2026-02', color: orange, label: 'Février'}
+        {date: '2026-02', color: lightBlue, label: 'Février'}
       ]
     ],
     hoverComponent: Hover,

--- a/src/components/ui/CalendarGrid/index.js
+++ b/src/components/ui/CalendarGrid/index.js
@@ -24,7 +24,6 @@ import LegendCalendar from '@/components/ui/LegendCalendar/index.js'
 // Default legend labels (reused pattern from previous calendar grid implementation)
 const defaultLegendLabels = [
   {color: fr.colors.decisions.artwork.major.blueFrance.default, label: 'Données présentes'},
-  {color: fr.colors.decisions.background.actionHigh.warning.hover, label: 'Données présentes mais anomalies'},
   {color: fr.colors.decisions.background.actionHigh.info.hover, label: 'Pas de prélèvement'},
   {color: fr.colors.decisions.background.actionHigh.grey.active, label: 'Non déclaré / pas de déclaration'}
 ]


### PR DESCRIPTION
## Description
Cette pull request retire l'utilisation de la couleur orange pour les états d'alerte/avertissement du calendrier parce que ce cas n'est plus géré pour le moment. L'orange a été remplacé par une teinte bleu clair, qui est la seule autre couleur par défaut disponible pour les libellés de légende, afin de maintenir la cohérence visuelle.

### Principaux changements :
- Remplacement de l'orange (`fr.colors.decisions.background.actionHigh.warning.hover`) par le bleu clair (`fr.colors.decisions.background.actionHigh.info.hover`) pour les surlignages des jours dans toutes les stories de `calendar-grid.stories.js`.
- Mise à jour des libellés de légende dans `calendar-grid.stories.js`.
- Suppression du libellé orange « warning » par défaut dans `index.js` pour que les légendes et le composant n'utilisent plus cette couleur.

### Raison :
- Le cas "warning" n'est plus pris en charge ; on retire donc sa couleur pour éviter toute ambiguïté. Le bleu clair est utilisé par défaut pour conserver une palette cohérente des légendes.
