### PR TITLE
Permettre de filtrer les points de prélèvements sur plusieurs communes

### DIFF
--- a/src/app/points-prelevement/page.js
+++ b/src/app/points-prelevement/page.js
@@ -48,7 +48,7 @@ const Page = () => {
     name: '',
     typeMilieu: '',
     status: '',
-    commune: '',
+    communes: [],
     usages: []
   })
   const [filteredPoints, setFilteredPoints] = useState([])
@@ -137,9 +137,11 @@ const Page = () => {
         matches &&= filters.usages.some(usage => point.usages.includes(usage))
       }
 
-      if (filters.commune && filters.commune.length > 0) {
-        const communeStr = `${point.commune.nom} - ${point.commune.code}`
-        matches &&= communeStr === filters.commune
+      if (filters.communes && filters.communes.length > 0) {
+        const communeStr = point.commune && point.commune.nom && point.commune.code
+          ? `${point.commune.nom} - ${point.commune.code}`
+          : null
+        matches &&= communeStr ? filters.communes.includes(communeStr) : false
       }
 
       return matches

--- a/src/components/map/map-filters.js
+++ b/src/components/map/map-filters.js
@@ -22,6 +22,8 @@ import {
 import Badge from '@mui/material/Badge'
 import debounce from 'lodash-es/debounce'
 
+import GroupedMultiselect from '@/components/ui/GroupedMultiselect/index.js'
+
 const MapFilters = ({filters, usagesOptions, typeMilieuOptions, statusOptions, communesOptions, onFilterChange, onClearFilters}) => {
   const [expanded, setExpanded] = useState(false)
   const [searchTerm, setSearchTerm] = useState(filters.name || '')
@@ -130,23 +132,16 @@ const MapFilters = ({filters, usagesOptions, typeMilieuOptions, statusOptions, c
               ))}
             </Select>
           </FormControl>
-          <FormControl size='small' className='w-full'>
-            <InputLabel id='filter-commune-label'>Commune</InputLabel>
-            <Select
-              labelId='filter-commune-label'
-              label='Commune'
-              value={filters.commune}
-              onChange={e =>
-                onFilterChange({commune: e.target.value})}
-            >
-              <MenuItem value=''>Toutes</MenuItem>
-              {communesOptions.map(commune => (
-                <MenuItem key={commune} value={commune}>
-                  {commune}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          <Box sx={{width: '100%', position: 'relative', zIndex: 1}}>
+            <GroupedMultiselect
+              label='Communes'
+              placeholder='Toutes les communes'
+              value={filters.communes}
+              options={communesOptions}
+              disabled={communesOptions.length === 0}
+              onChange={value => onFilterChange({communes: value})}
+            />
+          </Box>
           <FormGroup row>
             {usagesOptions.map(option => (
               <FormControlLabel

--- a/src/components/map/points-list-header.js
+++ b/src/components/map/points-list-header.js
@@ -31,7 +31,7 @@ const PointsListHeader = ({filters, resultsCount, typeMilieuOptions, usagesOptio
           name: '',
           typeMilieu: '',
           status: '',
-          commune: '',
+          communes: [],
           usages: []
         })}
     />


### PR DESCRIPTION
## Description
Offre la possibilité de sélectionner plusieurs communes pour les filtrer les points de prélèvements sur la carte.

---
<img width="608" height="565" alt="Capture d’écran 2025-10-16 à 09 42 15" src="https://github.com/user-attachments/assets/1e42f894-95d2-4e2a-a538-dc4d6a7581e7" />
<img width="599" height="559" alt="Capture d’écran 2025-10-16 à 09 42 25" src="https://github.com/user-attachments/assets/88d638b9-c809-4469-a4bc-b64ecb5fddfa" />

---

Fix #248 