### PR TITLE
Autoriser les icônes du DSFR dans EntityHeader

### DIFF
--- a/src/components/ui/EntityHeader/entity-header.stories.js
+++ b/src/components/ui/EntityHeader/entity-header.stories.js
@@ -1,5 +1,4 @@
 import {
-  AccountBoxOutlined,
   CalendarMonthOutlined,
   LocalShippingOutlined,
   AgricultureOutlined
@@ -16,7 +15,7 @@ const storyMeta = {
       control: 'text',
       description: 'Titre principal de l’entité.'
     },
-    titleIcon: {
+    iconId: {
       description: 'Icône affichée à côté du titre.'
     },
     metas: {
@@ -38,7 +37,7 @@ const storyMeta = {
   },
   args: {
     title: '100 - Exploitation',
-    titleIcon: AccountBoxOutlined,
+    iconId: 'fr-icon-user-line',
     metas: [
       {icon: CalendarMonthOutlined, content: 'Dernier prélèvement le 10 août 2025'}
     ],

--- a/src/components/ui/EntityHeader/index.js
+++ b/src/components/ui/EntityHeader/index.js
@@ -9,7 +9,7 @@ import TagsList from '@/components/ui/TagsList/index.js'
 
 const EntityHeader = ({
   title,
-  titleIcon: TitleIcon,
+  iconId,
   metas,
   rightBadges,
   tags,
@@ -34,7 +34,7 @@ const EntityHeader = ({
                   fontWeight: 500
                 }}
               >
-                {TitleIcon && <TitleIcon sx={{fontSize: 38}} />}
+                {iconId && <span className={iconId} />}
                 {title}
               </Box>
             </Box>
@@ -81,12 +81,12 @@ const EntityHeader = ({
             </Box>
           )}
         </Box>
-        <Box sx={{paddingLeft: `${TitleIcon ? 4 : 0}px`}}>
+        <Box sx={{paddingLeft: `${iconId ? 4 : 0}px`}}>
           <MetasList metas={metas} />
         </Box>
       </Box>
 
-      <Box sx={{paddingLeft: `${TitleIcon ? 4 : 0}px`}}>
+      <Box sx={{paddingLeft: `${iconId ? 4 : 0}px`}}>
         {children}
       </Box>
     </Box>


### PR DESCRIPTION
Cette *pull request* met à jour le composant `EntityHeader` afin de simplifier la gestion des icônes.  
Au lieu de passer un composant React pour l’icône (`titleIcon`), le composant accepte désormais une chaîne de caractères `iconId`, utilisée comme classe CSS pour afficher l’icône.  
Ce changement affecte à la fois l’implémentation du composant et ses stories dans Storybook.

## Simplification de la gestion des icônes

- Le composant `EntityHeader` a été modifié pour accepter une propriété `iconId` (chaîne de caractères) à la place du composant React `titleIcon`.  
- Toutes les références internes à `TitleIcon` ont été remplacées par `iconId`.  
- L’icône est désormais rendue via un élément `<span>` utilisant la classe CSS correspondante.

## Mises à jour de Storybook

- Les stories Storybook du composant `EntityHeader` ont été mises à jour pour utiliser la nouvelle propriété `iconId` à la place de `titleIcon`.  
- La documentation et les arguments par défaut ont été ajustés en conséquence.