### PR TITLE
Suppression de la prop titleIcon dans <EntityHeader/>

### DIFF
--- a/src/components/ui/EntityHeader/entity-header.stories.js
+++ b/src/components/ui/EntityHeader/entity-header.stories.js
@@ -1,5 +1,4 @@
 import {
-  AccountBoxOutlined,
   CalendarMonthOutlined,
   LocalShippingOutlined,
   AgricultureOutlined
@@ -15,9 +14,6 @@ const storyMeta = {
     title: {
       control: 'text',
       description: 'Titre principal de l’entité.'
-    },
-    titleIcon: {
-      description: 'Icône affichée à côté du titre.'
     },
     metas: {
       control: 'object',
@@ -38,7 +34,6 @@ const storyMeta = {
   },
   args: {
     title: '100 - Exploitation',
-    titleIcon: AccountBoxOutlined,
     metas: [
       {icon: CalendarMonthOutlined, content: 'Dernier prélèvement le 10 août 2025'}
     ],

--- a/src/components/ui/EntityHeader/index.js
+++ b/src/components/ui/EntityHeader/index.js
@@ -9,7 +9,6 @@ import TagsList from '@/components/ui/TagsList/index.js'
 
 const EntityHeader = ({
   title,
-  titleIcon: TitleIcon,
   metas,
   rightBadges,
   tags,
@@ -34,7 +33,6 @@ const EntityHeader = ({
                   fontWeight: 500
                 }}
               >
-                {TitleIcon && <TitleIcon sx={{fontSize: 38}} />}
                 {title}
               </Box>
             </Box>
@@ -81,12 +79,12 @@ const EntityHeader = ({
             </Box>
           )}
         </Box>
-        <Box sx={{paddingLeft: `${TitleIcon ? 4 : 0}px`}}>
+        <Box>
           <MetasList metas={metas} />
         </Box>
       </Box>
 
-      <Box sx={{paddingLeft: `${TitleIcon ? 4 : 0}px`}}>
+      <Box>
         {children}
       </Box>
     </Box>


### PR DESCRIPTION
Cette prop ne sera jamais utilisée. Si exceptionnellement, une icône doit être ajoutée, elle sera directement gérée au niveau de `title`