### PR TITLE
Corriger l'espacement dans ListItem

### DIFF
--- a/src/components/ui/ListItem/index.js
+++ b/src/components/ui/ListItem/index.js
@@ -5,6 +5,7 @@ import {Typography, Box} from '@mui/material'
 
 import MetasList from '@/components/ui/MetasList/index.js'
 import TagsList from '@/components/ui/TagsList/index.js'
+import './style.css'
 
 const CardTitle = ({title, subtitle, subtitleIcon: SubtitleIcon, rightIcons}) => (
   <Box>
@@ -65,7 +66,7 @@ const ListItem = ({
     <Card
       start={<TagsList tags={tags} />}
       title={<CardTitle title={title} subtitle={subtitle} subtitleIcon={subtitleIcon} rightIcons={rightIcons} />}
-      end={<MetasList metas={metas} />}
+      end={metas?.length > 0 ? <Box className='mt-2'><MetasList metas={metas} /></Box> : null}
       border={border || false}
       size='small'
       style={background === 'primary' ? primaryBackgroundStyle : secondaryBackgroundStyle}

--- a/src/components/ui/ListItem/style.css
+++ b/src/components/ui/ListItem/style.css
@@ -1,0 +1,6 @@
+/* Supprime le margin automatique du DSFR sur les cartes */
+.fr-card__end {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+


### PR DESCRIPTION
Cette pull request introduit une légère amélioration de l’interface utilisateur du composant **`ListItem`** en affinant l’affichage des métadonnées et en appliquant des styles personnalisés aux éléments de la carte.  
Les principaux changements incluent le rendu conditionnel du composant **`MetasList`** et l’ajout d’un fichier CSS pour ajuster les marges et espacements par défaut des cartes.

### Améliorations du rendu UI

* Le composant **`ListItem`** ne rend désormais le composant **`MetasList`** que si le tableau `metas` contient des éléments, en l’enveloppant dans un **`Box`** avec une marge supérieure pour un meilleur espacement.

### Mise à jour du style

* Ajout d’un nouveau fichier CSS (**`style.css`**) au composant **`ListItem`** afin de remplacer les marges et espacements par défaut de la section finale de la carte, garantissant une apparence cohérente avec le design system.

### **AVANT**
<img width="1218" height="287" alt="Capture d’écran 2025-10-20 à 10 59 17" src="https://github.com/user-attachments/assets/4426a5b7-c025-417b-89db-dbea7ee36ef3" />

### **APRÈS**
<img width="1218" height="228" alt="Capture d’écran 2025-10-20 à 10 59 32" src="https://github.com/user-attachments/assets/0a667c21-dff0-4b0f-a1e6-9b1ea60bfb4c" />
