### PR TITLE
Ajout du champ "remarque interne"

### DIFF
--- a/src/components/form/point-form.js
+++ b/src/components/form/point-form.js
@@ -101,6 +101,15 @@ const PointForm = ({
         }}
         onChange={e => setPoint(prev => ({...prev, remarque: e.target.value}))}
       />
+      <Input
+        textArea
+        label='Remarque interne (Visible uniquement par les instructeurs)'
+        nativeTextAreaProps={{
+          placeholder: 'Entrer une remarque interne',
+          defaultValue: point?.remarque_interne
+        }}
+        onChange={e => setPoint(prev => ({...prev, remarque_interne: e.target.value}))}
+      />
       <AccordionCentered
         isExpanded={isExpanded}
         setIsExpanded={setIsExpanded}


### PR DESCRIPTION
Cette PR ajoute le champ "remarque interne" au formulaire de création/édition d'un point de prélèvement.

## Capture : 

<img width="1277" height="545" alt="image" src="https://github.com/user-attachments/assets/eeccb8c0-de68-4b11-975c-9a0480186105" />

---

PR backend https://github.com/MTES-MCT/prelevements-deau-api/pull/94