### PR TITLE
Adaptation de la taille des icônes des métas

### DIFF
--- a/src/components/ui/MetasList/index.js
+++ b/src/components/ui/MetasList/index.js
@@ -4,7 +4,7 @@ import uniqBy from 'lodash-es/uniqBy'
 
 import Icon from '@/components/ui/Icon/index.js'
 
-const MetasList = ({metas = []}) => {
+const MetasList = ({metas = [], size = 'md'}) => {
   const uniqueMetas = uniqBy(metas, 'content')
 
   return (
@@ -29,7 +29,7 @@ const MetasList = ({metas = []}) => {
           {
             (icon || iconId)
             && <Icon iconId={iconId} iconElement={icon}
-              sx={{fontSize: 18, color: fr.colors.decisions.text.default.grey.default}}
+              sx={{fontSize: size === 'sm' ? 16 : 18, color: fr.colors.decisions.text.default.grey.default}}
               title={icon?.displayName || icon?.name}
               aria-label={icon?.displayName || icon?.name}
             />

--- a/src/components/ui/MetasList/metas-list.stories.js
+++ b/src/components/ui/MetasList/metas-list.stories.js
@@ -15,6 +15,15 @@ Liste de métadonnées à afficher. Format: [{iconId?, icon?, content}]. Les pro
 Si "iconId" est fourni, il sera prioritaire sur "icon" et une icone du DSFR sera importée avec cette className.
 
 Si "icon" est fourni, il doit s'agir d'un composant React (ex: une icône MUI).`
+    },
+    size: {
+      control: {type: 'radio'},
+      options: ['sm', 'md'],
+      description: 'Taille des icônes (sm: 16px, md: 18px)',
+      table: {
+        type: {summary: 'string'},
+        defaultValue: {summary: 'md'}
+      }
     }
   },
   args: {
@@ -23,25 +32,44 @@ Si "icon" est fourni, il doit s'agir d'un composant React (ex: une icône MUI).`
       {icon: AccessTimeOutlined, content: 'Horodatage'},
       {icon: CalendarTodayOutlined, content: 'Date'},
       {content: 'Sans icône'}
-    ]
+    ],
+    size: 'md'
   }
 }
 
 const renderMetasList = args => {
-  const {metas} = args
+  const {metas, size} = args
 
-  return <MetasList metas={metas} />
+  return <MetasList metas={metas} size={size} />
 }
 
 export default meta
 
 export const Default = {render: renderMetasList}
 
+export const Small = {
+  args: {
+    size: 'sm'
+  },
+  render: renderMetasList
+}
+
 export const SansIcones = {
   args: {
     metas: [
       {content: 'Aucune icône 1'},
       {content: 'Aucune icône 2'}
+    ]
+  },
+  render: renderMetasList
+}
+
+export const AvecIconeDSFR = {
+  args: {
+    metas: [
+      {iconId: 'fr-icon-calendar-line', content: 'Avec icône DSFR'},
+      {iconId: 'fr-icon-time-line', content: 'Horodatage'},
+      {icon: InfoOutlined, content: 'Avec icône MUI'}
     ]
   },
   render: renderMetasList


### PR DESCRIPTION
Cette pull request améliore le composant d’interface **`MetasList`** en ajoutant la prise en charge de tailles d’icônes configurables et en enrichissant sa documentation dans **Storybook**.  
Les principales modifications incluent l’ajout d’une prop `size` pour contrôler la taille des icônes, la mise à jour du composant pour utiliser cette nouvelle prop, ainsi que l’extension des stories Storybook afin de démontrer la nouvelle fonctionnalité et son utilisation avec différents types d’icônes.

## 🧩 Améliorations du composant

- Ajout d’une prop `size` au composant `MetasList`, permettant de choisir entre une petite taille (`sm` : 16 px) et une taille moyenne (`md` : 18 px).  
  La valeur par défaut est `md`.
- Mise à jour de la logique d’affichage des icônes pour utiliser la prop `size` de manière dynamique.

## 📘 Améliorations de Storybook

- Documentation de la nouvelle prop `size` dans les contrôles et descriptions de Storybook.  
- Mise à jour des arguments par défaut et des stories pour inclure et illustrer la prop `size`, avec notamment une nouvelle variante **« Small »**.  
- Ajout d’une nouvelle story **« AvecIconeDSFR »** pour présenter l’utilisation avec des icônes DSFR et MUI.
