### PR TITLE
Corrige l'affichage des fréquences agrégées

### DIFF
--- a/src/components/PrelevementsSeriesExplorer/aggregated-series-explorer.js
+++ b/src/components/PrelevementsSeriesExplorer/aggregated-series-explorer.js
@@ -7,7 +7,6 @@ import {
 import {Alert} from '@codegouvfr/react-dsfr/Alert'
 import {Select} from '@codegouvfr/react-dsfr/Select'
 import {Box} from '@mui/material'
-import {format} from 'date-fns'
 
 import ChartWithRangeSlider from './chart-with-range-slider.js'
 import {
@@ -32,6 +31,7 @@ import {buildDailyAndTimelineData} from '@/components/PrelevementsSeriesExplorer
 import CalendarGrid from '@/components/ui/CalendarGrid/index.js'
 import PeriodSelectorHeader from '@/components/ui/PeriodSelectorHeader/index.js'
 import {useManagedSelection} from '@/hook/use-managed-selection.js'
+import {parseLocalDateTime} from '@/utils/time.js'
 
 const DEFAULT_PARAMETER = 'volume prélevé'
 
@@ -166,10 +166,18 @@ const filterValuesByDateRange = (values, dateRange) => {
     return values
   }
 
-  const start = format(dateRange.start, 'yyyy-MM-dd')
-  const end = format(dateRange.end, 'yyyy-MM-dd')
+  return values.filter(entry => {
+    if (!entry?.date) {
+      return false
+    }
 
-  return values.filter(entry => entry?.date && entry.date >= start && entry.date <= end)
+    const parsed = parseLocalDateTime(entry.date)
+    if (!parsed) {
+      return false
+    }
+
+    return parsed >= dateRange.start && parsed <= dateRange.end
+  })
 }
 
 const AggregatedSeriesExplorer = ({

--- a/src/components/PrelevementsSeriesExplorer/util.test.js
+++ b/src/components/PrelevementsSeriesExplorer/util.test.js
@@ -68,6 +68,24 @@ test('parseLocalDate returns a local midnight Date instance', t => {
   t.deepEqual(date, new Date(2024, 8, 28, 0, 0, 0, 0))
 })
 
+test('parseLocalDate handles month-only ISO strings', t => {
+  const date = parseLocalDate('2024-11')
+  t.truthy(date)
+  t.deepEqual(date, new Date(2024, 10, 1, 0, 0, 0, 0))
+})
+
+test('parseLocalDate handles year-only ISO strings', t => {
+  const date = parseLocalDate('2024')
+  t.truthy(date)
+  t.deepEqual(date, new Date(2024, 0, 1, 0, 0, 0, 0))
+})
+
+test('parseLocalDate ignores time component when present', t => {
+  const date = parseLocalDate('2024-11-01 06:00')
+  t.truthy(date)
+  t.deepEqual(date, new Date(2024, 10, 1, 0, 0, 0, 0))
+})
+
 test('parseLocalDateTime parses time components safely', t => {
   const date = parseLocalDateTime('2024-09-28', '15:30:45')
   t.truthy(date)
@@ -83,6 +101,30 @@ test('parseLocalDateTime falls back to midnight when time missing', t => {
 test('parseLocalDateTime returns null for invalid dates', t => {
   const date = parseLocalDateTime('invalid')
   t.is(date, null)
+})
+
+test('parseLocalDateTime supports month precision dates', t => {
+  const date = parseLocalDateTime('2024-11')
+  t.truthy(date)
+  t.deepEqual(date, new Date(2024, 10, 1, 0, 0, 0, 0))
+})
+
+test('parseLocalDateTime supports year-only dates', t => {
+  const date = parseLocalDateTime('2024')
+  t.truthy(date)
+  t.deepEqual(date, new Date(2024, 0, 1, 0, 0, 0, 0))
+})
+
+test('parseLocalDateTime parses embedded time separated by space', t => {
+  const date = parseLocalDateTime('2024-11-01 06:00')
+  t.truthy(date)
+  t.deepEqual(date, new Date(2024, 10, 1, 6, 0, 0, 0))
+})
+
+test('parseLocalDateTime parses ISO datetime with seconds and timezone suffix', t => {
+  const date = parseLocalDateTime('2024-11-01T06:30:15Z')
+  t.truthy(date)
+  t.deepEqual(date, new Date(2024, 10, 1, 6, 30, 15, 0))
 })
 
 // periodsToDateRange tests

--- a/src/components/PrelevementsSeriesExplorer/utils/index.js
+++ b/src/components/PrelevementsSeriesExplorer/utils/index.js
@@ -8,6 +8,8 @@ import {
 
 import {CALENDAR_STATUS_COLORS} from '../constants/colors.js'
 
+import {parseLocalDateTime} from '@/utils/time.js'
+
 /**
  * Color priority map for calendar aggregation
  * Lower number = higher priority (more important to display)
@@ -115,20 +117,12 @@ export function buildSeriesMetadataMap(seriesList) {
  * @returns {Date|null}
  */
 export function parseLocalDate(dateString) {
-  if (typeof dateString !== 'string') {
+  const parsed = parseLocalDateTime(dateString)
+  if (!parsed) {
     return null
   }
 
-  const [yearStr, monthStr, dayStr] = dateString.split('-')
-  const year = Number(yearStr)
-  const month = Number(monthStr)
-  const day = Number(dayStr)
-
-  if ([year, month, day].some(value => Number.isNaN(value))) {
-    return null
-  }
-
-  return new Date(year, month - 1, day, 0, 0, 0, 0)
+  return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate(), 0, 0, 0, 0)
 }
 
 /**

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -64,47 +64,134 @@ export function normalizeDate(date) {
  * @param {string|null} [timeString] - HH:mm or HH:mm:ss
  * @returns {Date|null}
  */
-export const parseLocalDateTime = (dateString, timeString) => {
-  if (typeof dateString !== 'string') {
+const DATE_TIME_SEPARATORS = Object.freeze(['T', ' '])
+
+const splitDateTime = value => {
+  if (typeof value !== 'string') {
     return null
   }
 
-  const trimmedDate = dateString.trim()
-  if (!trimmedDate) {
+  const trimmed = value.trim()
+  if (!trimmed) {
     return null
   }
 
-  const [yearStr, monthStr, dayStr] = trimmedDate.split('-')
-  const year = Number(yearStr)
-  const month = Number(monthStr)
-  const day = Number(dayStr)
+  for (const separator of DATE_TIME_SEPARATORS) {
+    const separatorIndex = trimmed.indexOf(separator)
+    if (separatorIndex > 0) {
+      return {
+        datePart: trimmed.slice(0, separatorIndex),
+        inferredTime: trimmed.slice(separatorIndex + 1)
+      }
+    }
+  }
+
+  return {datePart: trimmed, inferredTime: null}
+}
+
+const parseDateComponents = datePart => {
+  const match = datePart.match(/^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?$/)
+  if (!match) {
+    return null
+  }
+
+  const year = Number(match[1])
+  const hasMonth = match[2] !== undefined
+  const hasDay = match[3] !== undefined
+  const month = hasMonth ? Number(match[2]) : 1
+  const day = hasDay ? Number(match[3]) : 1
 
   if (
-    Number.isNaN(year)
-    || Number.isNaN(month)
-    || Number.isNaN(day)
+    !Number.isInteger(year)
+    || !Number.isInteger(month)
+    || !Number.isInteger(day)
+    || month < 1
+    || month > 12
   ) {
     return null
   }
 
+  return {year, month, day}
+}
+
+const createBaseDate = ({year, month, day}) => {
   const baseDate = new Date(year, month - 1, day, 0, 0, 0, 0)
   if (Number.isNaN(baseDate.getTime())) {
     return null
   }
 
-  if (typeof timeString !== 'string' || timeString.trim() === '') {
+  if (baseDate.getFullYear() !== year || baseDate.getMonth() + 1 !== month) {
+    return null
+  }
+
+  return baseDate
+}
+
+const resolveTimeComponent = (explicitTime, inferredTime) => {
+  const explicit = typeof explicitTime === 'string' ? explicitTime.trim() : ''
+  const fallback = typeof inferredTime === 'string' ? inferredTime.trim() : ''
+  const candidate = explicit || fallback
+
+  if (!candidate) {
+    return null
+  }
+
+  const normalized = candidate
+    .replace(/z$/i, '')
+    .replace(/\.\d+$/, '')
+
+  const match = normalized.match(/^(\d{1,2}(?::\d{2}){1,2})/)
+  return match ? match[1] : null
+}
+
+const applyTimeComponent = (baseDate, timeValue) => {
+  if (!timeValue) {
     return baseDate
   }
 
-  const [hoursStr, minutesStr = '0', secondsStr = '0'] = timeString.split(':')
+  const [hoursStr, minutesStr = '0', secondsStr = '0'] = timeValue.split(':')
   const hours = Number(hoursStr)
   const minutes = Number(minutesStr)
   const seconds = Number(secondsStr)
 
-  const safeHours = Number.isNaN(hours) ? 0 : hours
-  const safeMinutes = Number.isNaN(minutes) ? 0 : minutes
-  const safeSeconds = Number.isNaN(seconds) ? 0 : seconds
+  if (
+    Number.isNaN(hours)
+    || Number.isNaN(minutes)
+    || Number.isNaN(seconds)
+    || hours < 0
+    || hours > 23
+    || minutes < 0
+    || minutes > 59
+    || seconds < 0
+    || seconds > 59
+  ) {
+    return null
+  }
 
-  baseDate.setHours(safeHours, safeMinutes, safeSeconds, 0)
+  baseDate.setHours(hours, minutes, seconds, 0)
   return baseDate
+}
+
+export const parseLocalDateTime = (dateString, timeString) => {
+  const splitResult = splitDateTime(dateString)
+  if (!splitResult) {
+    return null
+  }
+
+  const components = parseDateComponents(splitResult.datePart)
+  if (!components) {
+    return null
+  }
+
+  const baseDate = createBaseDate(components)
+  if (!baseDate) {
+    return null
+  }
+
+  const resolvedTime = resolveTimeComponent(timeString, splitResult.inferredTime)
+  if (!resolvedTime) {
+    return baseDate
+  }
+
+  return applyTimeComponent(baseDate, resolvedTime)
 }

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -120,7 +120,11 @@ const createBaseDate = ({year, month, day}) => {
     return null
   }
 
-  if (baseDate.getFullYear() !== year || baseDate.getMonth() + 1 !== month) {
+  if (
+    baseDate.getFullYear() !== year
+    || baseDate.getMonth() + 1 !== month
+    || baseDate.getDate() !== day
+  ) {
     return null
   }
 
@@ -168,8 +172,9 @@ const applyTimeComponent = (baseDate, timeValue) => {
     return null
   }
 
-  baseDate.setHours(hours, minutes, seconds, 0)
-  return baseDate
+  const result = new Date(baseDate)
+  result.setHours(hours, minutes, seconds, 0)
+  return result
 }
 
 export const parseLocalDateTime = (dateString, timeString) => {


### PR DESCRIPTION
## Constat
Seule la fréquence journalière s'affichait.

## Pourquoi
Les dates renvoyées pour les pas de temps inférieurs ou supérieurs au jour (ex. "2024-11-01 00:00" ou "2024-11") n'étaient pas interprétées correctement, donc les valeurs étaient filtrées et le graphique restait vide.

## Comment
Un parseur local gère désormais ces formats (année, mois, date+heure) et les filtres/chartes utilisent ce parseur unifié, avec tests mis à jour.