### PR TITLE
Ajout du volume totale prélevé déclaré à la liste des dossiers

### DIFF
--- a/src/components/declarations/dossier/dossier-card.js
+++ b/src/components/declarations/dossier/dossier-card.js
@@ -6,7 +6,8 @@ import {
   LocalDrinkOutlined,
   LocalShippingOutlined,
   TableRowsOutlined,
-  FactoryOutlined
+  FactoryOutlined,
+  WaterDropOutlined
 } from '@mui/icons-material'
 import {format} from 'date-fns'
 import {fr} from 'date-fns/locale'
@@ -14,6 +15,7 @@ import Link from 'next/link'
 
 import ListItem from '@/components/ui/ListItem/index.js'
 import {getDossierPeriodLabel} from '@/lib/dossier.js'
+import {formatNumber} from '@/utils/number.js'
 
 const rightIcons = {
   'camion-citerne': {
@@ -87,6 +89,17 @@ const metas = dossier => {
     {
       icon: TableRowsOutlined,
       content: typeDonnees(dossier.typeDonnees)
+    },
+    {
+      icon: WaterDropOutlined,
+      content: dossier.result?.totalVolumePreleve
+        ? (
+          <>
+            Volume prélevé : {formatNumber(dossier.result.totalVolumePreleve)}{' '}
+            <span aria-label='mètres cubes' role='text'>m³</span>
+          </>
+        )
+        : 'Aucun volume prélevé déclaré'
     }
   ]
 }


### PR DESCRIPTION
## Description
Pour chaque dossier de la liste de dossiers, on indique le `totalVolumePreleve`?
<img width="1135" height="154" alt="Capture d’écran 2025-11-19 à 17 47 37" src="https://github.com/user-attachments/assets/d7d4f00f-5b31-402f-80fc-0c0f2aaff3c1" />
<img width="272" height="58" alt="Capture d’écran 2025-11-19 à 17 47 50" src="https://github.com/user-attachments/assets/198c24a8-f405-4a63-930a-07cdad32f959" />

---

Fixes #303