### PR TITLE
feat(explorer): afficher les commentaires des paramètres sélectionnés

### DIFF
--- a/src/components/PrelevementsSeriesExplorer/index.js
+++ b/src/components/PrelevementsSeriesExplorer/index.js
@@ -59,6 +59,7 @@ import ChartWithRangeSlider from './chart-with-range-slider.js'
 import {DEFAULT_TRANSLATIONS} from './constants/parameters.js'
 import {formatPeriodLabel, getViewTypeLabel} from './formatters.js'
 import LoadingState from './loading-state.js'
+import ParameterComments from './parameter-comments.js'
 import ParameterSelector from './parameter-selector.js'
 import {useChartSeries} from './use-chart-series.js'
 import {useLoadSeriesValues} from './use-load-series-values.js'
@@ -270,6 +271,12 @@ const PrelevementsSeriesExplorer = ({
           onChange={handleParameterChange}
         />
       </Box>
+
+      {/* Parameter Comments */}
+      <ParameterComments
+        selectedParams={selectedParams}
+        parameterMap={parameterMap}
+      />
 
       {/* Loading state */}
       {showChart && isLoadingValues && (

--- a/src/components/PrelevementsSeriesExplorer/parameter-comments.js
+++ b/src/components/PrelevementsSeriesExplorer/parameter-comments.js
@@ -1,0 +1,77 @@
+/**
+ * ParameterComments Component
+ *
+ * Displays comments associated with selected parameters as discrete info alerts.
+ * Each comment shows the parameter label for context.
+ *
+ * @component
+ */
+
+'use client'
+
+import {useMemo} from 'react'
+
+import {Alert} from '@codegouvfr/react-dsfr/Alert'
+import {Box} from '@mui/material'
+
+/**
+ * Extracts comments from selected parameters
+ * @param {Array<string>} selectedParams - Selected parameter labels
+ * @param {Map} parameterMap - Map of parameterLabel to parameter metadata
+ * @returns {Array<{parameterLabel: string, comment: string}>} Comments with their parameter labels
+ */
+function extractParameterComments(selectedParams, parameterMap) {
+  const comments = []
+
+  for (const paramLabel of selectedParams) {
+    const param = parameterMap.get(paramLabel)
+    const comment = param?.extras?.commentaire
+
+    if (comment && typeof comment === 'string' && comment.trim()) {
+      comments.push({
+        parameterLabel: paramLabel,
+        comment: comment.trim()
+      })
+    }
+  }
+
+  return comments
+}
+
+/**
+ * ParameterComments displays info alerts for comments of selected parameters
+ *
+ * @param {Object} props - Component props
+ * @param {Array<string>} props.selectedParams - Currently selected parameter labels
+ * @param {Map} props.parameterMap - Map of parameterLabel to parameter metadata (including extras)
+ * @returns {JSX.Element|null} Alert components for each comment, or null if no comments
+ */
+const ParameterComments = ({selectedParams, parameterMap}) => {
+  const comments = useMemo(
+    () => extractParameterComments(selectedParams, parameterMap),
+    [selectedParams, parameterMap]
+  )
+
+  if (comments.length === 0) {
+    return null
+  }
+
+  return (
+    <Box className='flex flex-col gap-2'>
+      {comments.map(({parameterLabel, comment}) => (
+        <Alert
+          key={parameterLabel}
+          small
+          severity='info'
+          description={
+            <span>
+              <strong>{parameterLabel}</strong> : {comment}
+            </span>
+          }
+        />
+      ))}
+    </Box>
+  )
+}
+
+export default ParameterComments

--- a/src/components/PrelevementsSeriesExplorer/use-parameter-selection.js
+++ b/src/components/PrelevementsSeriesExplorer/use-parameter-selection.js
@@ -68,7 +68,8 @@ export function useParameterMetadata(seriesList) {
       color: colorMap.get(s.parameter),
       frequency: s.frequency,
       valueType: s.valueType,
-      seriesId: s._id
+      seriesId: s._id,
+      extras: s.extras
     }))
 
     // Use parameterLabel as key for direct lookup


### PR DESCRIPTION
## Description

Affiche les commentaires associés aux séries de données sous le sélecteur de paramètres.

## Changements

- Ajout du champ `extras` dans les métadonnées de paramètre pour accéder à `extras.commentaire`
- Création du composant `ParameterComments` qui affiche les commentaires sous forme d'alertes info discrètes
- Intégration du composant dans `PrelevementsSeriesExplorer`

## Comportement

- Seuls les commentaires des paramètres actuellement sélectionnés sont affichés
- Chaque commentaire indique clairement le paramètre concerné (ex: **volume prélevé #1** : RAS)
- Les alertes utilisent le style `small` du DSFR pour rester discrètes

## Exemple de données

```json
{
  "_id": "6908f040d9e8015607982cb4",
  "parameter": "volume prélevé",
  "extras": {
    "commentaire": "RAS"
  }
}
```