### PR TITLE
Correction du parsing de dates pour Safari

### DIFF
--- a/src/lib/exploitation.js
+++ b/src/lib/exploitation.js
@@ -1,3 +1,5 @@
+import {safeParseDate} from '@/lib/format-date.js'
+
 export function sortByStatus(a, b) {
   if (a.statut === 'En activité' && b.statut !== 'En activité') {
     return -1
@@ -11,8 +13,8 @@ export function sortByStatus(a, b) {
 }
 
 export function sortByEndDate(a, b) {
-  const endDateA = a.date_fin ? new Date(a.date_fin) : null
-  const endDateB = b.date_fin ? new Date(b.date_fin) : null
+  const endDateA = safeParseDate(a.date_fin)
+  const endDateB = safeParseDate(b.date_fin)
   if (endDateA && endDateB) {
     if (endDateA < endDateB) {
       return 1
@@ -41,8 +43,21 @@ export function sortByRecurrence(a, b) {
     return 0
   }
 
-  const debutDateA = new Date(a.date_debut)
-  const debutDateB = new Date(b.date_debut)
+  const debutDateA = safeParseDate(a.date_debut)
+  const debutDateB = safeParseDate(b.date_debut)
+
+  if (!debutDateA && debutDateB) {
+    return 1
+  }
+
+  if (!debutDateB && debutDateA) {
+    return -1
+  }
+
+  if (!debutDateA && !debutDateB) {
+    return 0
+  }
+
   const yearA = debutDateA.getFullYear()
   const yearB = debutDateB.getFullYear()
 

--- a/src/lib/format-date.js
+++ b/src/lib/format-date.js
@@ -3,16 +3,48 @@ import {
   startOfMonth,
   endOfMonth,
   startOfWeek,
-  endOfWeek
+  endOfWeek,
+  parseISO,
+  isValid
 } from 'date-fns'
 import {fr} from 'date-fns/locale'
+
+/**
+ * Safely parse a date string into a Date object.
+ * Uses parseISO for ISO strings to ensure cross-browser compatibility (Safari).
+ * @param {string|Date} dateInput - Date string or Date object
+ * @returns {Date|null} Valid Date object or null if invalid
+ */
+export function safeParseDate(dateInput) {
+  if (!dateInput) {
+    return null
+  }
+
+  if (dateInput instanceof Date) {
+    return isValid(dateInput) ? dateInput : null
+  }
+
+  // Only accept string or Date input, otherwise return null
+  if (typeof dateInput === 'string') {
+    const date = parseISO(dateInput)
+    return isValid(date) ? date : null
+  }
+
+  // Unsupported type
+  return null
+}
 
 function formatDate(date) {
   if (!date) {
     return null
   }
 
-  return format(date, 'dd/MM/yyyy')
+  const parsedDate = safeParseDate(date)
+  if (!parsedDate) {
+    return null
+  }
+
+  return format(parsedDate, 'dd/MM/yyyy')
 }
 
 export function formatFullDateFr(dateString) {
@@ -20,7 +52,11 @@ export function formatFullDateFr(dateString) {
     return null
   }
 
-  const date = new Date(dateString)
+  const date = safeParseDate(dateString)
+  if (!date) {
+    return null
+  }
+
   const dayNum = date.getDate()
   const day = dayNum === 1 ? '1er' : String(dayNum).padStart(2, '0')
   const month = format(date, 'MMMM', {locale: fr})


### PR DESCRIPTION
## Problème

Sur Safari, la page `/preleveurs/72` (et potentiellement d'autres pages) affichait une erreur 500 :
```
RangeError: Invalid time value
```

Ce problème n'apparaissait pas sur Firefox ou Chrome.

## Cause

Safari est plus strict que les autres navigateurs concernant le parsing de dates avec `new Date(dateString)`. Certains formats ISO (par exemple sans timezone) ne sont pas acceptés par Safari.

## Solution

- Ajout d'une fonction `safeParseDate()` dans `format-date.js` qui utilise `parseISO` de `date-fns` pour un parsing fiable et cross-browser
- Modification de `formatDate` et `formatFullDateFr` pour utiliser cette fonction
- Modification des fonctions de tri dans `exploitation.js` pour utiliser `safeParseDate`

## Tests

Les tests existants passent toujours ✅