### PR TITLE
Améliorer UX/UI des cartes

### DIFF
--- a/src/app/points-prelevement/page.js
+++ b/src/app/points-prelevement/page.js
@@ -192,7 +192,7 @@ const Page = () => {
             selectedPoint={selectedPointId ? points.find(point => selectedPointId === point.id_point) : null}
             handleSelectedPoint={handleSelectedPoint}
             mapStyle={style}
-            options={{hash: true}}
+            options={{hash: true, cooperativeGestures: false}}
           />
           <Box
             sx={{

--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -192,6 +192,12 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint, mapSty
       center: [55.55, -21.13],
       zoom: 10,
       hash: options.hash ?? false,
+      cooperativeGestures: options.cooperativeGestures ?? true,
+      locale: {
+        'CooperativeGesturesHandler.WindowsHelpText': 'Utilisez Ctrl + molette pour zoomer sur la carte',
+        'CooperativeGesturesHandler.MacHelpText': 'Utilisez ⌘ + molette pour zoomer sur la carte',
+        'CooperativeGesturesHandler.MobileHelpText': 'Utilisez deux doigts pour déplacer la carte'
+      },
       attributionControl: {compact: true}
     }
 
@@ -294,7 +300,7 @@ const Map = ({points, filteredPoints, selectedPoint, handleSelectedPoint, mapSty
     return () => {
       map.remove()
     }
-  }, [mapStyle, points, handleSelectedPoint, options.hash])
+  }, [mapStyle, points, handleSelectedPoint, options.hash, options.cooperativeGestures])
 
   // Mise à jour des sources lorsque les points filtrés changent
   useEffect(() => {


### PR DESCRIPTION
## Description

Cette PR améliore l'expérience utilisateur des cartes sur les pages de détail.

Fixes #407

## Modifications

### 1. Suppression des coordonnées de l'URL
- Ajout d'une prop `options` au composant `Map` pour configurer le comportement
- `hash` est désactivé par défaut (pas de coordonnées/zoom dans l'URL)
- `hash` reste activé sur la page principale `/points-prelevement` où c'est utile

### 2. Prévention du zoom accidentel
- Activation de `cooperativeGestures` par défaut sur les cartes de détail
- L'utilisateur doit utiliser Ctrl+molette (ou ⌘+molette sur Mac) pour zoomer
- Sur mobile, deux doigts sont requis pour naviguer
- Messages d'aide en français
- Désactivé sur la carte principale `/points-prelevement` pour une interaction complète

### 3. Nettoyage
- Suppression de `debug: true` qui n'avait pas sa place en production