### PR TITLE
fix(info-card): improve display of preleveur name with fallback for m…

### DIFF
--- a/src/app/preleveurs/[id]/page.js
+++ b/src/app/preleveurs/[id]/page.js
@@ -45,8 +45,8 @@ const InfoCard = ({preleveur}) => {
         <li>
           <Icon iconId='ri-user-line' style={iconColorStyle} />
           <span>
-            {preleveur.civilite && preleveur.nom && preleveur.prenom
-              ? `${preleveur.civilite} ${preleveur.nom} ${preleveur.prenom}`
+            {preleveur.civilite || preleveur.nom || preleveur.prenom
+              ? `${preleveur.civilite || ''} ${preleveur.nom || ''} ${preleveur.prenom || ''}`.trim()
               : 'Non renseigné'}
           </span>
         </li>


### PR DESCRIPTION
This pull request makes a small improvement to the display logic for the preleveur's name in the `InfoCard` component. The change ensures that if any part of the name (`civilite`, `nom`, or `prenom`) is present, it will be shown, and missing parts will be replaced with an empty string to avoid displaying "undefined". The result is then trimmed to remove extra spaces, and "Non renseigné" is only shown if all fields are missing. ([src/app/preleveurs/[id]/page.jsL48-R49](diffhunk://#diff-4d535285009c10ff6cc3cd8f537de46ad05e9e25b35fa0b791ad6d5e822b5a1bL48-R49))…issing fields