### PR TITLE
refactor(auth): centraliser la configuration des URLs API et Frontend

### DIFF
--- a/src/app/api/auth/verify/[token]/route.js
+++ b/src/app/api/auth/verify/[token]/route.js
@@ -1,9 +1,7 @@
 import {NextResponse} from 'next/server'
 
+import {API_URL, FRONTEND_URL} from '@/app/api/util/request.js'
 import {getErrorReason} from '@/lib/auth-errors.js'
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL
-const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL || 'http://localhost:3000'
 
 /**
  * Route handler for magic link verification in dev mode.

--- a/src/app/api/util/request.js
+++ b/src/app/api/util/request.js
@@ -7,6 +7,7 @@ import {
 } from '@/lib/auth.js'
 
 export const API_URL = process.env.NEXT_PUBLIC_API_URL
+export const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL || 'https://prelevements-deau.beta.gouv.fr'
 
 export function getAuthorization() {
   const authToken = getToken()

--- a/src/app/auth/verify/[token]/route.js
+++ b/src/app/auth/verify/[token]/route.js
@@ -1,9 +1,7 @@
 import {NextResponse} from 'next/server'
 
+import {API_URL, FRONTEND_URL} from '@/app/api/util/request.js'
 import {getErrorReason} from '@/lib/auth-errors.js'
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL
-const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL || 'http://localhost:3000'
 
 /**
  * Route handler for magic link verification.


### PR DESCRIPTION
## Problème

En production, les liens magic d'authentification redirigeaient vers `localhost:3000` au lieu de l'URL de production.

La cause : les constantes `FRONTEND_URL` étaient dupliquées dans plusieurs fichiers avec un fallback hardcodé vers `http://localhost:3000`.

## Solution

Cette PR centralise la configuration des URLs dans `src/app/api/util/request.js` pour éviter la duplication et faciliter la maintenance.

### Changements

- ✅ Ajout de `export const FRONTEND_URL` dans `src/app/api/util/request.js`
- ✅ Mise à jour du fallback : `https://prelevements-deau.beta.gouv.fr` (au lieu de `http://localhost:3000`)
- ✅ Suppression des constantes dupliquées dans :
  - `src/app/auth/verify/[token]/route.js`
  - `src/app/api/auth/verify/[token]/route.js`
- ✅ Import des constantes depuis le fichier centralisé

### Avantages

- Une seule source de vérité pour les URLs
- Pas de risque de divergence entre les différentes routes
- Fallback cohérent avec l'environnement de production
- Plus facile à maintenir
