### PR TITLE
fix(config): convert tailwind config to ESM syntax

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+const config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -15,3 +15,5 @@ module.exports = {
   },
   plugins: []
 }
+
+export default config


### PR DESCRIPTION
Convert tailwind.config.js from CommonJS (module.exports) to ESM (export default) to fix intermittent 'module is not defined' ReferenceError during Next.js hot reload.

This aligns the config file with Next.js 15's native ESM module system.