### PR TITLE
Adaptation nomenclature API règles

### DIFF
--- a/src/components/PrelevementsSeriesExplorer/constants/parameters.js
+++ b/src/components/PrelevementsSeriesExplorer/constants/parameters.js
@@ -122,7 +122,7 @@ export const AGGREGATED_PARAMETERS = [
     precision: 0
   },
   {
-    parameter: 'conductivité électrique',
+    parameter: 'conductivité',
     unit: 'µS/cm',
     type: 'instantaneous',
     defaultTemporalOperator: 'mean',

--- a/src/components/form/regle-creation-form.js
+++ b/src/components/form/regle-creation-form.js
@@ -19,6 +19,7 @@ const emptyRegle = {
   unite: '',
   valeur: '',
   contrainte: '',
+  frequence: null,
   debut_validite: '',
   fin_validite: '',
   debut_periode: '',
@@ -33,8 +34,9 @@ const RegleCreationForm = ({preleveur, exploitations, documents}) => {
   const [regle, setRegle] = useState(emptyRegle)
 
   // Parameters that require a unit selection
-  const parametresRequiringUnite = ['Débit prélevé', 'Débit réservé']
+  const parametresRequiringUnite = ['débit prélevé', 'débit réservé']
   const isUniteRequired = parametresRequiringUnite.includes(regle.parametre)
+  const isFrequenceRequired = regle.parametre === 'volume prélevé'
 
   const isFormValid = regle.exploitations?.length > 0
     && regle.parametre
@@ -42,6 +44,7 @@ const RegleCreationForm = ({preleveur, exploitations, documents}) => {
     && regle.contrainte
     && regle.debut_validite
     && (!isUniteRequired || regle.unite)
+    && (!isFrequenceRequired || regle.frequence)
 
   const handleSubmit = withSubmit(
     async () => {

--- a/src/components/form/regle-form.js
+++ b/src/components/form/regle-form.js
@@ -13,25 +13,22 @@ import GroupedMultiselect from '@/components/ui/GroupedMultiselect/index.js'
 import {formatFullDateFr} from '@/lib/format-date.js'
 
 const contraintes = [
-  {value: 'minimum', label: 'Minimum (>)'},
-  {value: 'maximum', label: 'Maximum (<)'},
-  {value: 'moyenne', label: 'Moyenne (≃)'}
+  {value: 'min', label: 'Minimum (>)'},
+  {value: 'max', label: 'Maximum (<)'}
 ]
 
 // Mapping of parameters to their valid units
 const parametreUnites = {
-  'Volume journalier': ['m³'],
-  'Volume mensuel': ['m³'],
-  'Volume annuel': ['m³'],
-  'Relevé d\'index': ['m³'],
-  'Débit prélevé': ['L/s', 'm³/h'],
-  'Débit réservé': ['L/s', 'm³/h'],
-  Chlorures: ['mg/L'],
-  Nitrates: ['mg/L'],
-  Sulfates: ['mg/L'],
-  Température: ['degré Celsius'],
-  'Niveau piézométrique': ['m NGR'],
-  'Conductivité électrique': ['µS/cm'],
+  'volume prélevé': ['m³'],
+  'relevé d\'index': ['m³'],
+  'débit prélevé': ['L/s', 'm³/h'],
+  'débit réservé': ['L/s', 'm³/h'],
+  chlorures: ['mg/L'],
+  nitrates: ['mg/L'],
+  sulfates: ['mg/L'],
+  température: ['degrés Celsius'],
+  'niveau piézométrique': ['m NGR'],
+  conductivité: ['µS/cm'],
   pH: []
 }
 
@@ -141,6 +138,7 @@ const ParametreSection = ({regle, setRegle, fieldError}) => {
   }
 
   const showUniteField = requiresUniteSelection(regle.parametre)
+  const isVolumePreleveParametre = regle.parametre === 'volume prélevé'
 
   return (
     <DividerSection title='Paramètre et valeur'>
@@ -155,6 +153,25 @@ const ParametreSection = ({regle, setRegle, fieldError}) => {
         }}
         options={parametreOptions}
       />
+
+      {isVolumePreleveParametre && (
+        <Select
+          label='Fréquence *'
+          placeholder='Sélectionner une fréquence'
+          state={fieldError('frequence') ? 'error' : 'default'}
+          stateRelatedMessage={fieldError('frequence')}
+          nativeSelectProps={{
+            value: regle.frequence || '',
+            onChange: e => setRegle(prev => ({...prev, frequence: e.target.value}))
+          }}
+          options={[
+            {value: '', label: '-- Sélectionner --', disabled: true},
+            {value: '1 day', label: 'Journalier'},
+            {value: '1 month', label: 'Mensuel'},
+            {value: '1 year', label: 'Annuel'}
+          ]}
+        />
+      )}
 
       <div className={showUniteField ? 'grid grid-cols-2 gap-4' : ''}>
         {showUniteField && (

--- a/src/components/form/regles-form.js
+++ b/src/components/form/regles-form.js
@@ -13,31 +13,30 @@ import DayMonthSelector from '@/components/form/day-month-selector.js'
 import {emptyStringToNull} from '@/utils/string.js'
 
 const contraintes = [
-  'minimum',
-  'maximum'
+  'min',
+  'max'
 ]
 
 const parametres = [
-  'Volume journalier',
-  'Volume mensuel',
-  'Volume annuel',
-  'Débit prélevé',
-  'Débit réservé',
-  'Chlorures',
-  'Nitrates',
-  'Sulfates',
-  'Température',
-  'Niveau piézométrique',
-  'Conductivité électrique',
+  'volume prélevé',
+  'relevé d\'index',
+  'débit prélevé',
+  'débit réservé',
+  'chlorures',
+  'nitrates',
+  'sulfates',
+  'température',
+  'niveau piézométrique',
+  'conductivité',
   'pH'
 ]
 
 const unites = [
-  {value: 'm3', label: 'm³'},
+  {value: 'm³', label: 'm³'},
   {value: 'L/s', label: 'L/s'},
-  {value: 'm3/h', label: 'm³/h'},
+  {value: 'm³/h', label: 'm³/h'},
   {value: 'mg/L', label: 'mg/L'},
-  {value: 'degré Celsius', label: 'degrès Celsius'},
+  {value: 'degrés Celsius', label: 'degrés Celsius'},
   {value: 'm NGR', label: 'm NGR'},
   {value: 'µS/cm', label: 'µS/cm'}
 ]
@@ -47,6 +46,7 @@ const emptyRegle = {
   unite: '',
   valeur: '',
   contrainte: '',
+  frequence: '',
   debut_validite: '',
   fin_validite: '',
   debut_periode: '',
@@ -69,6 +69,11 @@ const ReglesForm = ({defaultRegles, setExploitation}) => {
 
     if (!regle.parametre || !regle.unite || !regle.valeur || !regle.contrainte || !regle.debut_validite) {
       setError('Les champs "Paramètre", "Unité", "Valeur", "Contrainte" et "Début de validité" sont requis.')
+      return
+    }
+
+    if (regle.parametre === 'volume prélevé' && !regle.frequence) {
+      setError('Le champ "Fréquence" est requis pour le paramètre "volume prélevé".')
       return
     }
 
@@ -109,6 +114,21 @@ const ReglesForm = ({defaultRegles, setExploitation}) => {
           label: parametre
         }))}
       />
+      {regle?.parametre === 'volume prélevé' && (
+        <Select
+          label='Fréquence *'
+          placeholder='Sélectionner une fréquence'
+          nativeSelectProps={{
+            value: regle?.frequence,
+            onChange: e => setRegle(prev => ({...prev, frequence: e.target.value}))
+          }}
+          options={[
+            {value: '1 day', label: 'Journalier'},
+            {value: '1 month', label: 'Mensuel'},
+            {value: '1 year', label: 'Annuel'}
+          ]}
+        />
+      )}
       <div className='grid grid-cols-2 gap-4'>
         <Select
           label='Unité *'

--- a/src/components/regle.js
+++ b/src/components/regle.js
@@ -20,8 +20,9 @@ const InfoRow = ({label, value, description}) => (
   </Box>
 )
 
-const RegleHeader = ({parametre, debutValidite, finValidite, debutPeriode, finPeriode, unite, valeur, contrainte}) => {
-  const {label, icon} = getParametreInfo(parametre)
+const RegleHeader = ({parametre, frequence, debutValidite, finValidite, debutPeriode, finPeriode, unite, valeur, contrainte}) => {
+  const parametreInfo = getParametreInfo(parametre, frequence)
+  const {label, icon} = parametreInfo || {label: parametre, icon: null}
 
   return (
     <Box className='flex flex-col w-full gap-4'>
@@ -59,6 +60,7 @@ const Regle = ({regle}) => (
     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
       <RegleHeader
         parametre={regle.parametre}
+        frequence={regle.frequence}
         debutValidite={regle.debut_validite}
         debutPeriode={regle.debut_periode}
         finValidite={regle.fin_validite}

--- a/src/components/regles/regles-list-card.js
+++ b/src/components/regles/regles-list-card.js
@@ -93,8 +93,8 @@ const RegleStatusBadge = ({status}) => {
   )
 }
 
-const RegleHeader = ({parametre, debutValidite, finValidite, debutPeriode, finPeriode, unite, valeur, contrainte, status}) => {
-  const parametreInfo = getParametreInfo(parametre)
+const RegleHeader = ({parametre, frequence, debutValidite, finValidite, debutPeriode, finPeriode, unite, valeur, contrainte, status}) => {
+  const parametreInfo = getParametreInfo(parametre, frequence)
   const label = parametreInfo?.label || parametre
   const icon = parametreInfo?.icon
 
@@ -144,6 +144,7 @@ const RegleItem = ({regle, preleveurId, status}) => {
           debutValidite={regle.debut_validite}
           finPeriode={regle.fin_periode}
           finValidite={regle.fin_validite}
+          frequence={regle.frequence}
           parametre={regle.parametre}
           status={status}
           unite={regle.unite}

--- a/src/components/regles/regles-list-card.stories.js
+++ b/src/components/regles/regles-list-card.stories.js
@@ -21,8 +21,9 @@ const periodDate = (month, day) => `0001-${String(month).padStart(2, '0')}-${Str
 // Mock data for different rule statuses
 const activeRule = {
   _id: 'active-1',
-  parametre: 'Volume annuel',
-  contrainte: 'maximum',
+  parametre: 'volume prélevé',
+  frequence: '1 year',
+  contrainte: 'max',
   valeur: 50_000,
   unite: 'm³',
   debut_validite: daysAgo(365),
@@ -41,8 +42,8 @@ const activeRule = {
 
 const activeSeasonalRuleInSeason = {
   _id: 'seasonal-in-1',
-  parametre: 'Débit prélevé',
-  contrainte: 'maximum',
+  parametre: 'débit prélevé',
+  contrainte: 'max',
   valeur: 150,
   unite: 'm³/h',
   debut_validite: daysAgo(365),
@@ -57,8 +58,9 @@ const activeSeasonalRuleInSeason = {
 
 const horsSaisonRule = {
   _id: 'hors-saison-1',
-  parametre: 'Volume mensuel',
-  contrainte: 'maximum',
+  parametre: 'volume prélevé',
+  frequence: '1 month',
+  contrainte: 'max',
   valeur: 5000,
   unite: 'm³',
   debut_validite: daysAgo(365),
@@ -78,8 +80,9 @@ const horsSaisonRule = {
 
 const aVenirRule = {
   _id: 'a-venir-1',
-  parametre: 'Volume journalier',
-  contrainte: 'maximum',
+  parametre: 'volume prélevé',
+  frequence: '1 day',
+  contrainte: 'max',
   valeur: 200,
   unite: 'm³',
   debut_validite: daysFromNow(30), // Starts in 30 days
@@ -98,8 +101,9 @@ const aVenirRule = {
 
 const obsoleteRule = {
   _id: 'obsolete-1',
-  parametre: 'Volume annuel',
-  contrainte: 'maximum',
+  parametre: 'volume prélevé',
+  frequence: '1 year',
+  contrainte: 'max',
   valeur: 75_000,
   unite: 'm³',
   debut_validite: daysAgo(1000),
@@ -118,8 +122,8 @@ const obsoleteRule = {
 
 const obsoleteSeasonalRule = {
   _id: 'obsolete-2',
-  parametre: 'Niveau piézométrique',
-  contrainte: 'minimum',
+  parametre: 'niveau piézométrique',
+  contrainte: 'min',
   valeur: -15,
   unite: 'm NGF',
   debut_validite: daysAgo(800),
@@ -149,7 +153,7 @@ const meta = {
     docs: {
       description: {
         component: `Composant affichant la liste des règles d'un préleveur avec distinction visuelle des différents statuts :
-        
+
 - **Active** : règle actuellement en vigueur (pas de badge)
 - **Hors saison** : règle active mais hors période saisonnière (badge bleu)
 - **À venir** : règle dont la date de début de validité n'est pas encore atteinte (badge violet)
@@ -324,43 +328,44 @@ export const ParametresDifferents = {
     regles: [
       {
         ...activeRule,
-        parametre: 'Volume annuel',
+        parametre: 'volume prélevé',
+        frequence: '1 year',
         valeur: 50_000,
         unite: 'm³'
       },
       {
         ...activeRule,
         _id: 'p2',
-        parametre: 'Débit prélevé',
+        parametre: 'débit prélevé',
         valeur: 120,
         unite: 'm³/h'
       },
       {
         ...activeRule,
         _id: 'p3',
-        parametre: 'Niveau piézométrique',
+        parametre: 'niveau piézométrique',
         valeur: -10,
         unite: 'm NGF',
-        contrainte: 'minimum'
+        contrainte: 'min'
       },
       {
         ...activeRule,
         _id: 'p4',
-        parametre: 'Température',
+        parametre: 'température',
         valeur: 25,
         unite: '°C'
       },
       {
         ...activeRule,
         _id: 'p5',
-        parametre: 'Conductivité électrique',
+        parametre: 'conductivité',
         valeur: 500,
         unite: 'µS/cm'
       },
       {
         ...activeRule,
         _id: 'p6',
-        parametre: 'Chlorures',
+        parametre: 'chlorures',
         valeur: 100,
         unite: 'mg/L'
       }

--- a/src/lib/regles.js
+++ b/src/lib/regles.js
@@ -11,28 +11,44 @@ import WaterOutlinedIcon from '@mui/icons-material/WaterOutlined'
 import {safeParseDate} from '@/lib/format-date.js'
 
 const regleParametres = {
-  'Volume annuel': {label: 'Volume prélevé annuel', icon: <OpacityOutlinedIcon />},
-  'Volume mensuel': {label: 'Volume prélevé mensuel', icon: <OpacityOutlinedIcon />},
-  'Volume journalier': {label: 'Volume prélevé journalier', icon: <OpacityOutlinedIcon />},
-  'Débit prélevé': {label: 'Débit prélevé', icon: <OilBarrelOutlinedIcon />},
-  'Débit réservé': {label: 'Débit réservé', icon: <WaterOutlinedIcon />},
-  'Niveau piézométrique': {label: 'Niveau piézométrique', icon: <HeightOutlinedIcon />},
-  'Conductivité électrique': {label: 'Conductivité électrique', icon: <OfflineBoltOutlinedIcon />},
-  Température: {label: 'Conductivité électrique', icon: <DeviceThermostatOutlinedIcon />},
-  Chlorures: {label: 'Concentration en chlorures', icon: <ScienceOutlinedIcon />},
-  Nitrates: {label: 'Concentration en nitrates', icon: <ScienceOutlinedIcon />},
-  Sulfates: {label: 'Concentration en sulfates', icon: <ScienceOutlinedIcon />},
-  Ph: {label: 'Ph', icon: <BloodtypeOutlinedIcon />},
-  Turbidité: {label: 'Turbidité', icon: <LocalDrinkOutlinedIcon />}
+  'volume prélevé': {
+    '1 day': {label: 'Volume prélevé journalier', icon: <OpacityOutlinedIcon />},
+    '1 month': {label: 'Volume prélevé mensuel', icon: <OpacityOutlinedIcon />},
+    '1 year': {label: 'Volume prélevé annuel', icon: <OpacityOutlinedIcon />},
+    default: {label: 'Volume prélevé', icon: <OpacityOutlinedIcon />}
+  },
+  'relevé d\'index': {label: 'Relevé d\'index', icon: <OpacityOutlinedIcon />},
+  'débit prélevé': {label: 'Débit prélevé', icon: <OilBarrelOutlinedIcon />},
+  'débit réservé': {label: 'Débit réservé', icon: <WaterOutlinedIcon />},
+  'niveau piézométrique': {label: 'Niveau piézométrique', icon: <HeightOutlinedIcon />},
+  conductivité: {label: 'Conductivité', icon: <OfflineBoltOutlinedIcon />},
+  température: {label: 'Température', icon: <DeviceThermostatOutlinedIcon />},
+  chlorures: {label: 'Concentration en chlorures', icon: <ScienceOutlinedIcon />},
+  nitrates: {label: 'Concentration en nitrates', icon: <ScienceOutlinedIcon />},
+  sulfates: {label: 'Concentration en sulfates', icon: <ScienceOutlinedIcon />},
+  pH: {label: 'pH', icon: <BloodtypeOutlinedIcon />},
+  turbidité: {label: 'Turbidité', icon: <LocalDrinkOutlinedIcon />}
 }
 
 const regleContrainte = {
-  minimum: '>',
-  maximum: '<',
-  moyenne: '≃'
+  min: '>',
+  max: '<'
 }
 
-export const getParametreInfo = parametre => regleParametres[parametre]
+export const getParametreInfo = (parametre, frequence) => {
+  const parametreData = regleParametres[parametre]
+  if (!parametreData) {
+    return null
+  }
+
+  // Si c'est volume prélevé, utiliser la fréquence pour obtenir le label spécifique
+  if (parametre === 'volume prélevé' && typeof parametreData === 'object' && !parametreData.label) {
+    return parametreData[frequence] || parametreData.default
+  }
+
+  return parametreData
+}
+
 export const getRegleContrainte = contrainte => regleContrainte[contrainte]
 
 /**


### PR DESCRIPTION
### Dépendances
⚠️ **Nécessite que la PR backend soit mergée en premier** : MTES-MCT/prelevements-deau-api#158

### Changements

#### Contraintes
- `'minimum'` / `'maximum'` → `'min'` / `'max'`
- Suppression de `'moyenne'` (non utilisée en base)

#### Paramètres
- Volumes unifiés : `'Volume journalier/mensuel/annuel'` → `'volume prélevé'`
- Nouveau champ `frequence` (nullable) : `'1 day'` / `'1 month'` / `'1 year'`
- Tous les paramètres en minuscules : `'Débit prélevé'` → `'débit prélevé'`
- Unités : `'degré Celsius'` → `'degrés Celsius'`, `'conductivité électrique'` → `'conductivité'`

#### Fichiers modifiés
- Formulaires de création/édition avec champ fréquence conditionnel
- Composants d'affichage (Regle, ReglesListCard)
- Mapping lib/regles.js avec support fréquence
- Stories mises à jour
