### PR TITLE
Le package timeseries-parser est chargé depuis github au lieu de npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@fabnum/prelevements-deau-timeseries-parsers": "^0.0.11",
+    "@fabnum/prelevements-deau-timeseries-parsers": "github:MTES-MCT/prelevements-deau-api.git#workspace=@fabnum/prelevements-deau-timeseries-parsers&head=testing",
     "date-fns": "^4.1.0",
     "flexsearch": "^0.7.43",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
Nous n'avons pas le contrôle du package sur npm, et ce sera plus simple de rester a jour dans les évolutions du package.

https://github.com/MTES-MCT/prelevements-deau-api/pull/166